### PR TITLE
fix argv for execve with shebang

### DIFF
--- a/tee/kernel/src/user/process.rs
+++ b/tee/kernel/src/user/process.rs
@@ -6,6 +6,7 @@ use crate::{
     fs::{
         fd::file::File,
         node::{tmpfs::TmpFsFile, FileAccessContext, INode},
+        path::Path,
         INIT,
     },
     rt::once::OnceCell,
@@ -75,6 +76,7 @@ pub fn start_init_process(vm_activator: &mut VirtualMemoryActivator) {
         let file = file.open(OpenFlags::empty())?;
 
         guard.start_executable(
+            &Path::new(b"/bin/init".to_vec()).unwrap(),
             &*file,
             &[CStr::from_bytes_with_nul(b"/bin/init\0").unwrap()],
             &[] as &[&CStr],

--- a/tee/kernel/src/user/process/thread.rs
+++ b/tee/kernel/src/user/process/thread.rs
@@ -407,11 +407,12 @@ impl ThreadGuard<'_> {
         }
 
         let file = node.open(OpenFlags::empty())?;
-        self.start_executable(&*file, argv, envp, ctx, vm_activator)
+        self.start_executable(path, &*file, argv, envp, ctx, vm_activator)
     }
 
     pub fn start_executable(
         &mut self,
+        path: &Path,
         file: &dyn OpenFileDescription,
         argv: &[impl AsRef<CStr>],
         envp: &[impl AsRef<CStr>],
@@ -422,7 +423,7 @@ impl ThreadGuard<'_> {
 
         // Load the elf.
         let cpu_state = vm_activator.activate(&virtual_memory, |vm| {
-            vm.start_executable(file, argv, envp, ctx, self.cwd.clone())
+            vm.start_executable(path, file, argv, envp, ctx, self.cwd.clone())
         })?;
 
         // Success! Commit the new state to the thread.


### PR DESCRIPTION
If a executable starting with a shebang is started the first argument is replaced with the path to the executable (which doesn't necessarily match argv[0]).