### PR TITLE
replace physical memory allocator

### DIFF
--- a/tee/kernel/src/fs.rs
+++ b/tee/kernel/src/fs.rs
@@ -1,4 +1,4 @@
-use crate::{memory::frame::NewAllocator, spin::lazy::Lazy};
+use crate::spin::lazy::Lazy;
 use constants::{physical_address, virtual_address};
 use x86_64::structures::paging::{frame::PhysFrameRangeInclusive, page::PageRangeInclusive};
 
@@ -29,14 +29,13 @@ fn load_static_file(
 
     let header_entry = PresentPageTableEntry::new(header_frame, PageTableFlags::GLOBAL);
     unsafe {
-        map_page(header_page, header_entry, &mut NewAllocator).expect("failed to map header");
+        map_page(header_page, header_entry).expect("failed to map header");
     }
 
     #[cfg(sanitize = "address")]
     crate::sanitize::map_shadow(
         header_page.start_address().as_ptr(),
         crate::sanitize::MIN_ALLOCATION_SIZE,
-        &mut NewAllocator,
     );
 
     let len = unsafe {
@@ -53,7 +52,7 @@ fn load_static_file(
 
         let input_entry = PresentPageTableEntry::new(input_frame, PageTableFlags::GLOBAL);
         unsafe {
-            map_page(input_page, input_entry, &mut NewAllocator).expect("failed to map content");
+            map_page(input_page, input_entry).expect("failed to map content");
         }
     }
 
@@ -66,7 +65,6 @@ fn load_static_file(
             .cast(),
         ((0x1000 + len).saturating_sub(crate::sanitize::MIN_ALLOCATION_SIZE))
             .next_multiple_of(crate::sanitize::MIN_ALLOCATION_SIZE),
-        &mut NewAllocator,
     );
 
     let first_input_page = header_page + 1;

--- a/tee/kernel/src/fs.rs
+++ b/tee/kernel/src/fs.rs
@@ -1,11 +1,8 @@
-use crate::spin::lazy::Lazy;
+use crate::{memory::frame::NewAllocator, spin::lazy::Lazy};
 use constants::{physical_address, virtual_address};
 use x86_64::structures::paging::{frame::PhysFrameRangeInclusive, page::PageRangeInclusive};
 
-use crate::memory::{
-    frame::FRAME_ALLOCATOR,
-    pagetable::{map_page, PageTableFlags, PresentPageTableEntry},
-};
+use crate::memory::pagetable::{map_page, PageTableFlags, PresentPageTableEntry};
 
 pub mod fd;
 pub mod node;
@@ -32,14 +29,14 @@ fn load_static_file(
 
     let header_entry = PresentPageTableEntry::new(header_frame, PageTableFlags::GLOBAL);
     unsafe {
-        map_page(header_page, header_entry, &mut &FRAME_ALLOCATOR).expect("failed to map header");
+        map_page(header_page, header_entry, &mut NewAllocator).expect("failed to map header");
     }
 
     #[cfg(sanitize = "address")]
     crate::sanitize::map_shadow(
         header_page.start_address().as_ptr(),
         crate::sanitize::MIN_ALLOCATION_SIZE,
-        &mut &FRAME_ALLOCATOR,
+        &mut NewAllocator,
     );
 
     let len = unsafe {
@@ -56,8 +53,7 @@ fn load_static_file(
 
         let input_entry = PresentPageTableEntry::new(input_frame, PageTableFlags::GLOBAL);
         unsafe {
-            map_page(input_page, input_entry, &mut &FRAME_ALLOCATOR)
-                .expect("failed to map content");
+            map_page(input_page, input_entry, &mut NewAllocator).expect("failed to map content");
         }
     }
 
@@ -70,7 +66,7 @@ fn load_static_file(
             .cast(),
         ((0x1000 + len).saturating_sub(crate::sanitize::MIN_ALLOCATION_SIZE))
             .next_multiple_of(crate::sanitize::MIN_ALLOCATION_SIZE),
-        &mut &FRAME_ALLOCATOR,
+        &mut NewAllocator,
     );
 
     let first_input_page = header_page + 1;

--- a/tee/kernel/src/limited_index.rs
+++ b/tee/kernel/src/limited_index.rs
@@ -1,0 +1,88 @@
+use core::{
+    iter::Step,
+    ops::{Index, IndexMut, RangeInclusive},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct LimitedIndex<const N: usize>(u16);
+
+impl<const N: usize> LimitedIndex<N> {
+    pub const MIN: Self = Self::new(0);
+    pub const MAX: Self = Self::new(N - 1);
+    pub const ALL: RangeInclusive<Self> = Self::MIN..=Self::MAX;
+
+    #[inline(always)]
+    pub const fn new(idx: usize) -> Self {
+        assert!(N <= u16::MAX as usize);
+
+        assert!(idx < N);
+        Self(idx as u16)
+    }
+
+    #[inline(always)]
+    pub const fn try_new(idx: usize) -> Option<Self> {
+        if idx < N {
+            Some(Self(idx as u16))
+        } else {
+            None
+        }
+    }
+
+    #[inline(always)]
+    pub const fn get(&self) -> usize {
+        self.0 as usize
+    }
+}
+
+impl<const N: usize> Step for LimitedIndex<N> {
+    #[inline(always)]
+    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+        end.0.checked_sub(start.0).map(usize::from)
+    }
+
+    #[inline(always)]
+    fn forward_checked(start: Self, count: usize) -> Option<Self> {
+        let idx = start.get().checked_add(count)?;
+        if idx < N {
+            Some(Self::new(idx))
+        } else {
+            None
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn forward_unchecked(start: Self, count: usize) -> Self {
+        Self(start.0.wrapping_add(count as u16))
+    }
+
+    #[inline(always)]
+    fn backward_checked(start: Self, count: usize) -> Option<Self> {
+        let idx = start.get().checked_sub(count)?;
+        Some(Self::new(idx))
+    }
+
+    #[inline(always)]
+    unsafe fn backward_unchecked(start: Self, count: usize) -> Self {
+        Self(start.0.wrapping_sub(count as u16))
+    }
+}
+
+impl<T, const N: usize> Index<LimitedIndex<N>> for [T; N] {
+    type Output = T;
+
+    fn index(&self, index: LimitedIndex<N>) -> &Self::Output {
+        unsafe {
+            // SAFETY: `index.get()` is always less than `N`.
+            self.get_unchecked(index.get())
+        }
+    }
+}
+
+impl<T, const N: usize> IndexMut<LimitedIndex<N>> for [T; N] {
+    fn index_mut(&mut self, index: LimitedIndex<N>) -> &mut Self::Output {
+        unsafe {
+            // SAFETY: `index.get()` is always less than `N`.
+            self.get_unchecked_mut(index.get())
+        }
+    }
+}

--- a/tee/kernel/src/main.rs
+++ b/tee/kernel/src/main.rs
@@ -49,6 +49,7 @@ mod error;
 mod exception;
 mod fs;
 mod host;
+mod limited_index;
 mod logging;
 mod memory;
 mod panic;

--- a/tee/kernel/src/memory/frame.rs
+++ b/tee/kernel/src/memory/frame.rs
@@ -13,9 +13,7 @@ use constants::physical_address::DYNAMIC;
 use crossbeam_utils::atomic::AtomicCell;
 use usize_conversions::{usize_from, FromUsize};
 use x86_64::{
-    structures::paging::{
-        FrameAllocator, FrameDeallocator, PageSize, PhysFrame, Size2MiB, Size4KiB,
-    },
+    structures::paging::{FrameAllocator, FrameDeallocator, PageSize, PhysFrame, Size2MiB},
     PhysAddr,
 };
 
@@ -56,24 +54,6 @@ static L2: L2SuperGroup = L2SuperGroup::new();
 static PHYSICAL_ADDRESSES: PhysicalAddressSuperGroup = PhysicalAddressSuperGroup::new();
 /// This contains the chunk and group index for every for every slot.
 static REVERSE_MAP: ReverseMap = ReverseMap::new();
-
-#[derive(Clone, Copy)]
-pub struct NewAllocator;
-
-unsafe impl FrameAllocator<Size4KiB> for NewAllocator {
-    fn allocate_frame(&mut self) -> Option<PhysFrame> {
-        let frame = allocate_frame();
-        Some(frame)
-    }
-}
-
-impl FrameDeallocator<Size4KiB> for NewAllocator {
-    unsafe fn deallocate_frame(&mut self, frame: PhysFrame) {
-        unsafe {
-            deallocate_frame(frame);
-        }
-    }
-}
 
 /// Allocate a 4KiB frame.
 pub fn allocate_frame() -> PhysFrame {

--- a/tee/kernel/src/memory/frame.rs
+++ b/tee/kernel/src/memory/frame.rs
@@ -1,252 +1,652 @@
+//! A fast concurrent physical memory allocator. The design is heavily inspired
+//! by LLFree.
+
 use core::{
+    hint::unreachable_unchecked,
     mem::size_of,
-    ops::{Index, IndexMut},
-    sync::atomic::{AtomicBool, Ordering},
+    ops::{Bound, Range, RangeBounds},
+    sync::atomic::{AtomicU16, AtomicU32, AtomicU64, Ordering},
 };
 
-use crate::spin::mutex::Mutex;
-use alloc::vec::Vec;
-use arrayvec::ArrayVec;
-use bit_field::BitArray;
-use log::{debug, warn};
-use usize_conversions::usize_from;
-use x86_64::structures::paging::{FrameAllocator, FrameDeallocator, PhysFrame, Size2MiB, Size4KiB};
+use bit_field::BitField;
+use constants::physical_address::DYNAMIC;
+use crossbeam_utils::atomic::AtomicCell;
+use usize_conversions::{usize_from, FromUsize};
+use x86_64::{
+    structures::paging::{
+        FrameAllocator, FrameDeallocator, PageSize, PhysFrame, Size2MiB, Size4KiB,
+    },
+    PhysAddr,
+};
 
-use crate::supervisor;
+use crate::{limited_index::LimitedIndex, per_cpu::PerCpu, supervisor};
 
-pub static FRAME_ALLOCATOR: BitmapFrameAllocator = BitmapFrameAllocator::new();
+// The dynamic physical memory space is organized into a hierachy:
+// Level 0 (L0): A "chunk" is a 2MiB array of 4KiB pages that fit.
+// Level 1 (L1): Multiple chunks form a "group". A group can have an owning
+//               thread and only the owning thread is allowed to allocate from
+//               the group (deallocation is always allowed).
+// Level 2 (L2): The array of all groups is called the "super-group".
+//
+// Dynamic physical memory is lazily hot-plugged. The supervisor allows us to
+// hot-plug 2MiB "slots" of memory at an address of its choosing. We assign a
+// chunk a slot by storing it in `PHYSICAL_ADDRESSES`.
 
-pub struct BitmapFrameAllocator {
-    is_donating: AtomicBool,
-    state: Mutex<BitmapFrameAllocatorState>,
-}
+const SLOTS_ORDER: usize = 15;
+const CHUNK_ORDER: usize = 9;
+const GROUP_ORDER: usize = 3;
+const SUPER_GROUP_ORDER: usize = SLOTS_ORDER - GROUP_ORDER;
 
-impl BitmapFrameAllocator {
-    const fn new() -> Self {
-        Self {
-            is_donating: AtomicBool::new(false),
-            state: Mutex::new(BitmapFrameAllocatorState {
-                r#static: ArrayVec::new_const(),
-                dynamic: Vec::new(),
-            }),
-        }
-    }
-}
+const SLOTS: usize = 1 << SLOTS_ORDER;
+const CHUNK_SIZE: usize = 1 << CHUNK_ORDER;
+const GROUP_SIZE: usize = 1 << GROUP_ORDER;
+const SUPER_GROUP_SIZE: usize = 1 << SUPER_GROUP_ORDER;
 
-struct BitmapFrameAllocatorState {
-    r#static: ArrayVec<Bitmap, 1>,
-    dynamic: Vec<Bitmap>,
-}
+// Information about which frames are used and which are free is stored in
+// three levels:
+/// L0 just contains a single bit for every frame.
+static L0: L0SuperGroup = L0SuperGroup::new();
+/// L1 contains the number of free bits for every chunk.
+static L1: L1SuperGroup = L1SuperGroup::new();
+/// L2 contains the number of free bits for every group as well as whether the
+/// group is owned by a thread.
+static L2: L2SuperGroup = L2SuperGroup::new();
 
-impl BitmapFrameAllocatorState {
-    fn bitmaps(&mut self) -> impl Iterator<Item = &mut Bitmap> + '_ {
-        self.r#static.iter_mut().chain(self.dynamic.iter_mut())
-    }
+/// This contains a slot index (physical address) for every chunk.
+static PHYSICAL_ADDRESSES: PhysicalAddressSuperGroup = PhysicalAddressSuperGroup::new();
+/// This contains the chunk and group index for every for every slot.
+static REVERSE_MAP: ReverseMap = ReverseMap::new();
 
-    fn add_bitmap(&mut self, bitmap: Bitmap) {
-        // Try pushing into the statically sized vector...
-        match self.r#static.try_push(bitmap) {
-            Ok(_) => {}
-            Err(err) => {
-                // ...or fall back to pushing into the dynamic vector.
-                self.dynamic.push(err.element());
-            }
-        }
-    }
+#[derive(Clone, Copy)]
+pub struct NewAllocator;
 
-    fn swap_remove(&mut self, idx: usize) {
-        if idx < self.r#static.len() {
-            self.r#static.swap_remove(idx);
-        } else {
-            self.dynamic.swap_remove(idx - self.r#static.len());
-        }
-    }
-
-    /// Return's true when a donation is needed to grow the dynamic buffer.
-    fn needs_donation(&self) -> Option<usize> {
-        if self.dynamic.capacity() == 0 {
-            // Make sure to request at least a page worth of capacity.
-            return Some(4096usize.div_ceil(size_of::<Bitmap>()).next_power_of_two());
-        }
-
-        if self.dynamic.len() * 4 > self.dynamic.capacity() * 3 {
-            return Some(self.dynamic.capacity() * 2);
-        }
-
-        None
-    }
-
-    /// Donate the capacity of a vector.
-    fn donate_dynamic_vector(&mut self, dynamic: &mut Vec<Bitmap>) {
-        assert!(dynamic.is_empty());
-
-        // Check if the donated vector has more capacity.
-        if self.dynamic.capacity() >= dynamic.capacity() {
-            warn!("rejecting donation");
-            return;
-        }
-
-        // Swap the vectors and move the elements over.
-        core::mem::swap(&mut self.dynamic, dynamic);
-        self.dynamic.append(dynamic);
-    }
-}
-
-impl Index<usize> for BitmapFrameAllocatorState {
-    type Output = Bitmap;
-
-    fn index(&self, idx: usize) -> &Self::Output {
-        if idx < self.r#static.len() {
-            &self.r#static[idx]
-        } else {
-            &self.dynamic[idx - self.r#static.len()]
-        }
-    }
-}
-
-impl IndexMut<usize> for BitmapFrameAllocatorState {
-    fn index_mut(&mut self, idx: usize) -> &mut Self::Output {
-        if idx < self.r#static.len() {
-            &mut self.r#static[idx]
-        } else {
-            &mut self.dynamic[idx - self.r#static.len()]
-        }
-    }
-}
-
-unsafe impl FrameAllocator<Size4KiB> for &BitmapFrameAllocator {
+unsafe impl FrameAllocator<Size4KiB> for NewAllocator {
     fn allocate_frame(&mut self) -> Option<PhysFrame> {
-        let mut state = loop {
-            let mut state = self.state.lock();
-
-            if let Some(cap) = state.needs_donation() {
-                let res = self.is_donating.compare_exchange(
-                    false,
-                    true,
-                    Ordering::SeqCst,
-                    Ordering::SeqCst,
-                );
-                if res.is_ok() {
-                    // We acquired the rights to donate.
-                    debug!("preparing to donate with capacity {cap}");
-
-                    // Drop the mutex, so that we can allocate on the heap.
-                    drop(state);
-
-                    // Allocate a vector.
-                    let mut donation = Vec::with_capacity(cap);
-
-                    // Donate the vector.
-                    state = self.state.lock();
-                    state.donate_dynamic_vector(&mut donation);
-
-                    // Drop the mutex again to release the previous allocation.
-                    drop(state);
-                    drop(donation);
-
-                    self.is_donating.store(false, Ordering::SeqCst);
-
-                    continue;
-                }
-            }
-
-            break state;
-        };
-
-        // Try to allocate from the existing bitmaps.
-        if let Some(frame) = state.bitmaps().find_map(|bitmap| bitmap.allocate()) {
-            return Some(frame);
-        }
-
-        // Create a new bitmap and allocate from it.
-        let mut bitmap = Bitmap::new()?;
-        let frame = bitmap.allocate().unwrap();
-        state.add_bitmap(bitmap);
-
+        let frame = allocate_frame();
         Some(frame)
     }
 }
 
-impl FrameDeallocator<Size4KiB> for &BitmapFrameAllocator {
+impl FrameDeallocator<Size4KiB> for NewAllocator {
     unsafe fn deallocate_frame(&mut self, frame: PhysFrame) {
-        let mut state = self.state.lock();
-        let mut i = 0;
+        unsafe {
+            deallocate_frame(frame);
+        }
+    }
+}
+
+/// Allocate a 4KiB frame.
+pub fn allocate_frame() -> PhysFrame {
+    let mut guard = PerCpu::get().private_allocator_state.borrow_mut();
+
+    loop {
+        let state = guard.get_or_insert_with(|| L2.claim());
+
         loop {
-            let bitmap = &mut state[i];
-            if !bitmap.contains(frame) {
-                i += 1;
+            if let Some(new_l2_free) = state.free.checked_sub(1) {
+                // Try to find an available frame.
+                for chunk_idx in ChunkIndex::ALL {
+                    let free = &mut state.l1_metadata[chunk_idx];
+                    if let Some(new_free) = free.checked_sub(1) {
+                        let chunk = &L0.groups[state.group_idx].chunks[chunk_idx];
+                        let frame_idx = unsafe { chunk.find_free() };
+                        *free = new_free;
+
+                        let slot_idx = state.physical_addresses[chunk_idx];
+                        let base = PhysFrame::from(slot_idx);
+                        let address = PhysFrame::containing_address(base.start_address())
+                            + u64::from_usize(frame_idx.get());
+                        state.free = new_l2_free;
+                        return address;
+                    }
+                }
+            }
+
+            // Immediately try again if the global metadata contained some
+            // recently freed frames.
+            if state.refresh() {
                 continue;
             }
 
-            unsafe {
-                bitmap.deallocate(frame);
+            // Hot-plug more memory.
+            if let Some(chunk_idx) = state.allocated_bitmask.find_zero() {
+                let address = (&supervisor::ALLOCATOR).allocate_frame().unwrap();
+                let slot_idx = SlotIndex::from(address);
+                state.physical_addresses[chunk_idx] = slot_idx;
+                state.allocated_bitmask.set(chunk_idx, true);
+                state.l1_metadata[chunk_idx] = CHUNK_SIZE as u16;
+                REVERSE_MAP.set(slot_idx, state.group_idx, chunk_idx);
+                state.free += CHUNK_SIZE as u32;
+            } else {
+                // Abort and drop ownership of the group. We'll have to use a
+                // new group.
+                guard.take();
+                break;
             }
-            if bitmap.used == 0 {
-                state.swap_remove(i);
-            }
-
-            return;
         }
     }
 }
 
-struct Bitmap {
-    base: PhysFrame<Size2MiB>,
-    used: u16,
-    bitmap: [u8; 64],
-}
+/// Deallocate a 4KiB frame.
+///
+/// # Safety
+///
+/// The caller has to ensure that the frame was originally allocated using
+/// [`allocate_frame`] and that it is no longer in use.
+pub unsafe fn deallocate_frame(frame: PhysFrame) {
+    // Get the group, chunk and frame indices.
+    let frame_2mib = PhysFrame::containing_address(frame.start_address());
+    let slot_idx = SlotIndex::from(frame_2mib);
+    let (group_idx, chunk_idx) = REVERSE_MAP.get(slot_idx);
+    let frame_idx = frame - PhysFrame::containing_address(frame_2mib.start_address());
+    let frame_idx = FrameIndex::new(usize_from(frame_idx));
 
-impl Bitmap {
-    pub fn new() -> Option<Self> {
-        let base = (&supervisor::ALLOCATOR).allocate_frame()?;
-        Some(Self {
-            base,
-            used: 0,
-            bitmap: [0; 64],
-        })
+    let chunk = &L0.groups[group_idx].chunks[chunk_idx];
+    unsafe {
+        chunk.deallocate(frame_idx);
     }
 
-    pub fn allocate(&mut self) -> Option<PhysFrame> {
-        if self.used >= 512 {
-            return None;
-        }
-
-        self.used += 1;
-
-        let idx = (0..512u16)
-            .find(|&i| !self.bitmap.get_bit(usize::from(i)))
-            .unwrap();
-        self.bitmap.set_bit(usize::from(idx), true);
-
-        let base_addr = self.base.start_address();
-        let base_frame = PhysFrame::containing_address(base_addr);
-        Some(base_frame + u64::from(idx))
-    }
-
-    pub fn contains(&self, frame: PhysFrame) -> bool {
-        let base_addr = self.base.start_address();
-        let start_frame = PhysFrame::containing_address(base_addr);
-        let end_frame = start_frame + 511;
-        (start_frame..=end_frame).contains(&frame)
-    }
-
-    pub unsafe fn deallocate(&mut self, frame: PhysFrame) {
-        let base_addr = self.base.start_address();
-        let base_frame = PhysFrame::containing_address(base_addr);
-
-        let offset = frame - base_frame;
-        let offset = usize_from(offset);
-        self.bitmap.set_bit(offset, false);
-
-        self.used -= 1;
-    }
-}
-
-impl Drop for Bitmap {
-    fn drop(&mut self) {
-        assert_eq!(self.used, 0);
+    let mut guard = PerCpu::get().private_allocator_state.borrow_mut();
+    if let Some(state) = guard.as_mut().filter(|state| group_idx == state.group_idx) {
+        state.l1_metadata[chunk_idx] += 1;
+        state.free += 1;
+    } else {
+        let free = L1.groups[group_idx].chunks[chunk_idx]
+            .free
+            .fetch_add(1, Ordering::SeqCst);
         unsafe {
-            (&supervisor::ALLOCATOR).deallocate_frame(self.base);
+            L2.groups[group_idx].deallocate();
         }
+
+        // If the chunk is now completly unused, try to take ownership of the
+        // group, so that the chunk can be released.
+        if usize::from(free) + 1 == CHUNK_SIZE {
+            if let Ok((free, allocated_bitmask)) = L2.groups[group_idx].claim(|_| true) {
+                drop(unsafe { PrivateState::new(group_idx, free, allocated_bitmask) });
+            }
+        }
+    }
+}
+
+/// Release private state owned by the thread. This function should be called
+/// before the thread is halted.
+pub fn release_private() {
+    PerCpu::get().private_allocator_state.borrow_mut().take();
+}
+
+struct L0Chunk {
+    /// A bitfield for each frame in the chunk:
+    /// 0 -> the frame is not in use, 1 -> the frame is in use
+    free: [AtomicU64; 8],
+}
+
+const _: () = assert!(size_of::<L0Chunk>() * 8 == CHUNK_SIZE);
+
+impl L0Chunk {
+    const fn new() -> Self {
+        Self {
+            free: [const { AtomicU64::new(0) }; 8],
+        }
+    }
+
+    /// # Safety
+    ///
+    /// The caller has to ensure that the chunk is owned and that at least one
+    /// bit is free.
+    unsafe fn find_free(&self) -> FrameIndex {
+        for (idx, bits) in self.free.iter().enumerate() {
+            let value = bits.load(Ordering::SeqCst);
+            let trailing_ones = value.trailing_ones();
+            if trailing_ones >= 64 {
+                continue;
+            }
+            bits.fetch_or(1 << trailing_ones, Ordering::SeqCst);
+            let full_idx = idx * 64 + usize_from(trailing_ones);
+            return FrameIndex::new(full_idx);
+        }
+
+        unsafe { unreachable_unchecked() }
+    }
+
+    /// Mark a frame as no longer being in use.
+    ///
+    /// # Safety
+    ///
+    /// The caller has to ensure that the frame is no longer in use.
+    unsafe fn deallocate(&self, frame_idx: FrameIndex) {
+        let idx = frame_idx.get() / 64;
+        self.free[idx].fetch_and(!(1 << (frame_idx.get() % 64)), Ordering::SeqCst);
+    }
+}
+
+struct L0Group {
+    chunks: ChunkArray<L0Chunk>,
+}
+
+impl L0Group {
+    const fn new() -> Self {
+        Self {
+            chunks: [const { L0Chunk::new() }; GROUP_SIZE],
+        }
+    }
+}
+
+#[repr(align(64))]
+struct L0SuperGroup {
+    groups: GroupArray<L0Group>,
+}
+
+impl L0SuperGroup {
+    const fn new() -> Self {
+        Self {
+            groups: [const { L0Group::new() }; SUPER_GROUP_SIZE],
+        }
+    }
+}
+
+struct L1ChunkMetadata {
+    // The number of free bits in the chunk
+    free: AtomicU16,
+}
+
+impl L1ChunkMetadata {
+    const fn new() -> Self {
+        Self {
+            free: AtomicU16::new(0),
+        }
+    }
+}
+
+struct L1GroupMetadata {
+    chunks: ChunkArray<L1ChunkMetadata>,
+    _padding: [u8; 48],
+}
+
+impl L1GroupMetadata {
+    const fn new() -> Self {
+        // Make sure the group fits in a cacheline.
+        const _: () = assert!(size_of::<L1GroupMetadata>() == 64);
+
+        Self {
+            chunks: [const { L1ChunkMetadata::new() }; GROUP_SIZE],
+            _padding: [0; 48],
+        }
+    }
+}
+
+#[repr(align(64))]
+struct L1SuperGroup {
+    groups: GroupArray<L1GroupMetadata>,
+}
+
+impl L1SuperGroup {
+    const fn new() -> Self {
+        Self {
+            groups: [const { L1GroupMetadata::new() }; SUPER_GROUP_SIZE],
+        }
+    }
+}
+
+struct L2GroupMetadata {
+    bits: AtomicU32,
+}
+
+impl L2GroupMetadata {
+    /// Contains the number of free bits in all chunks.
+    const FREE_BITS: Range<usize> = 0..CHUNK_ORDER + GROUP_ORDER + 1;
+    /// Contains a bool indicating whether this group is owned by a CPU.
+    const OWNED_BIT: usize = Self::FREE_BITS.end;
+    /// Contains one bit for each chunk indicating whether a physical memory
+    /// has been been hot-swapped in.
+    const L1_ALLOCATED_BITS: Range<usize> = Self::OWNED_BIT + 1..Self::OWNED_BIT + 1 + GROUP_SIZE;
+
+    const fn new() -> Self {
+        Self {
+            bits: AtomicU32::new(0),
+        }
+    }
+
+    const TOTAL: u32 = (CHUNK_SIZE * GROUP_SIZE) as u32;
+    const FREE_LIMIT: u32 = Self::TOTAL * 7 / 8;
+    const ALLOCATED_LIMIT: u32 = Self::TOTAL / 8;
+
+    pub fn is_free(available: u32) -> bool {
+        (Bound::Excluded(Self::FREE_LIMIT), Bound::Unbounded).contains(&available)
+    }
+
+    pub fn is_allocated(available: u32) -> bool {
+        (Bound::Unbounded, Bound::Excluded(Self::ALLOCATED_LIMIT)).contains(&available)
+    }
+
+    pub fn is_partial(available: u32) -> bool {
+        !Self::is_free(available) && !Self::is_allocated(available)
+    }
+
+    pub fn is_not_completly_used(available: u32) -> bool {
+        available != 0
+    }
+
+    /// Inspect a group and optionally try to take ownership of the group. The
+    /// `check` function is called with the number of available frames, so that
+    /// the caller can decide whether they want to take ownership of the group.
+    pub fn claim(&self, mut check: impl FnMut(u32) -> bool) -> Result<(u32, ChunkBitmask), ()> {
+        let mut bits = self.bits.load(Ordering::SeqCst);
+        loop {
+            // Make sure the metadata doesn't already have an owner.
+            let has_owner = bits.get_bit(Self::OWNED_BIT);
+            if has_owner {
+                return Err(());
+            }
+
+            // Calculate the number of free bits. Chunks that don't yet have
+            // memory swapped in are considered "potentially available".
+            let allocated_bitmask = ChunkBitmask::new(bits.get_bits(Self::L1_ALLOCATED_BITS) as u8);
+            let free = bits.get_bits(Self::FREE_BITS);
+            let available = free + allocated_bitmask.count_zeros() * CHUNK_SIZE as u32;
+            // Make sure the caller is fine with the number of available frames.
+            if !check(available) {
+                return Err(());
+            }
+
+            let mut new_bits = bits;
+            new_bits.set_bits(Self::FREE_BITS, 0);
+            new_bits.set_bit(Self::OWNED_BIT, true);
+            match self
+                .bits
+                .compare_exchange(bits, new_bits, Ordering::SeqCst, Ordering::SeqCst)
+            {
+                Ok(_) => break Ok((free, allocated_bitmask)),
+                Err(new_bits) => bits = new_bits,
+            }
+        }
+    }
+
+    /// Deallocate a frame in the group.
+    pub unsafe fn deallocate(&self) {
+        self.bits
+            .fetch_add(1 << Self::FREE_BITS.start, Ordering::SeqCst);
+    }
+}
+
+#[repr(align(64))]
+struct L2SuperGroup {
+    groups: GroupArray<L2GroupMetadata>,
+}
+
+impl L2SuperGroup {
+    const fn new() -> Self {
+        Self {
+            groups: [const { L2GroupMetadata::new() }; SUPER_GROUP_SIZE],
+        }
+    }
+
+    fn claim(&self) -> PrivateState {
+        // Prefer partially used groups over free groups.
+        for check_fn in [L2GroupMetadata::is_partial, L2GroupMetadata::is_free] {
+            for idx in GroupIndex::ALL {
+                let group = &self.groups[idx];
+                if let Ok((free, allocated_bitmask)) = group.claim(check_fn) {
+                    return unsafe { PrivateState::new(idx, free, allocated_bitmask) };
+                }
+            }
+        }
+
+        // Fall back to any non-owned group.
+        loop {
+            for idx in GroupIndex::ALL {
+                let group = &self.groups[idx];
+                if let Ok((free, allocated_bitmask)) =
+                    group.claim(L2GroupMetadata::is_not_completly_used)
+                {
+                    return unsafe { PrivateState::new(idx, free, allocated_bitmask) };
+                }
+            }
+        }
+    }
+}
+
+/// The index of a frame inside a chunk.
+type FrameIndex = LimitedIndex<CHUNK_SIZE>;
+/// An array of chunks (also called a group).
+type ChunkArray<T> = [T; GROUP_SIZE];
+/// The index of a chunk in a group.
+type ChunkIndex = LimitedIndex<GROUP_SIZE>;
+/// An array of groups (also called a super-group).
+type GroupArray<T> = [T; SUPER_GROUP_SIZE];
+/// The index of a group in a super-group.
+type GroupIndex = LimitedIndex<SUPER_GROUP_SIZE>;
+
+/// Contains a bit for each chunk.
+#[derive(Debug, Clone, Copy)]
+struct ChunkBitmask {
+    bits: u8,
+}
+
+impl ChunkBitmask {
+    fn new(bits: u8) -> Self {
+        const _: () = assert!(u8::BITS >= GROUP_SIZE as u32);
+        Self { bits }
+    }
+
+    fn count_zeros(self) -> u32 {
+        self.bits.count_zeros() - (u8::BITS - GROUP_SIZE as u32)
+    }
+
+    fn find_zero(self) -> Option<ChunkIndex> {
+        ChunkIndex::try_new(usize_from(self.bits.trailing_ones()))
+    }
+
+    fn set(&mut self, idx: ChunkIndex, value: bool) {
+        self.bits.set_bit(idx.get(), value);
+    }
+}
+
+type SlotArray<T> = [T; SLOTS];
+type SlotIndex = LimitedIndex<SLOTS>;
+
+impl From<PhysFrame<Size2MiB>> for SlotIndex {
+    fn from(value: PhysFrame<Size2MiB>) -> Self {
+        let idx = (value.start_address().as_u64() - DYNAMIC.start()) / Size2MiB::SIZE;
+        SlotIndex::new(usize_from(idx))
+    }
+}
+
+impl From<SlotIndex> for PhysFrame<Size2MiB> {
+    fn from(value: SlotIndex) -> Self {
+        let address = DYNAMIC.start() + u64::from_usize(value.get()) * Size2MiB::SIZE;
+        PhysFrame::containing_address(PhysAddr::new(address))
+    }
+}
+
+#[derive(Debug)]
+pub struct PrivateState {
+    group_idx: GroupIndex,
+    // private copy of the relevants parts of the l2 metadata
+    allocated_bitmask: ChunkBitmask,
+    free: u32,
+    // private copy of the l1 metadata
+    l1_metadata: ChunkArray<u16>,
+    // private copy of the physical addresses
+    physical_addresses: ChunkArray<SlotIndex>,
+}
+
+impl PrivateState {
+    /// # Safety
+    ///
+    /// The caller has to ensure that the group was just allocated by
+    /// `try_set_cpu`.
+    unsafe fn new(group_idx: GroupIndex, free: u32, allocated_bitmask: ChunkBitmask) -> Self {
+        let mut l1_metadata = [0; GROUP_SIZE];
+        for chunk_idx in ChunkIndex::ALL {
+            l1_metadata[chunk_idx] = L1.groups[group_idx].chunks[chunk_idx]
+                .free
+                .swap(0, Ordering::SeqCst);
+        }
+
+        let mut physical_addresses = [SlotIndex::MIN; GROUP_SIZE];
+        for chunk_idx in ChunkIndex::ALL {
+            physical_addresses[chunk_idx] = PHYSICAL_ADDRESSES.groups[group_idx].chunks[chunk_idx]
+                .slot
+                .load();
+        }
+
+        Self {
+            free,
+            group_idx,
+            allocated_bitmask,
+            l1_metadata,
+            physical_addresses,
+        }
+    }
+
+    /// Refresh the metadata about available resources by looking at the global
+    /// data. Returns true if any resources were claimed.
+    ///
+    /// The main purpose of this function is to take into account frames that
+    /// were freed by another thread after the global metadata was copied to
+    /// the private state.
+    fn refresh(&mut self) -> bool {
+        let mut claimed_any = false;
+
+        for idx in ChunkIndex::ALL {
+            let claimed = L1.groups[self.group_idx].chunks[idx]
+                .free
+                .swap(0, Ordering::SeqCst);
+            self.l1_metadata[idx] += claimed;
+            claimed_any |= claimed != 0;
+        }
+
+        let mut mask = !0;
+        mask.set_bits(L2GroupMetadata::FREE_BITS, 0);
+        let bits = L2.groups[self.group_idx]
+            .bits
+            .fetch_and(mask, Ordering::SeqCst);
+        let claimed = bits.get_bits(L2GroupMetadata::FREE_BITS);
+        self.free += claimed;
+        claimed_any |= claimed != 0;
+
+        claimed_any
+    }
+}
+
+impl Drop for PrivateState {
+    fn drop(&mut self) {
+        self.refresh();
+
+        // Hot-unplug completly unused chunks.
+        for i in ChunkIndex::ALL {
+            if self.free < CHUNK_SIZE as u32 && self.l1_metadata[i] == CHUNK_SIZE as u16 {
+                self.l1_metadata[i] = 0;
+                self.allocated_bitmask.set(i, false);
+                let slot_idx = self.physical_addresses[i];
+                let frame = PhysFrame::from(slot_idx);
+                unsafe {
+                    (&supervisor::ALLOCATOR).deallocate_frame(frame);
+                }
+                self.free -= CHUNK_SIZE as u32;
+            }
+        }
+
+        // Write back the L1 metadata.
+        for i in ChunkIndex::ALL {
+            PHYSICAL_ADDRESSES.groups[self.group_idx].chunks[i]
+                .slot
+                .store(self.physical_addresses[i]);
+            L1.groups[self.group_idx].chunks[i]
+                .free
+                .fetch_add(self.l1_metadata[i], Ordering::SeqCst);
+        }
+
+        // Write back the L2 metadata.
+        let metadata = &L2.groups[self.group_idx];
+        let mut bits = metadata.bits.load(Ordering::SeqCst);
+        loop {
+            let mut new_bits = bits;
+            new_bits.set_bits(
+                L2GroupMetadata::FREE_BITS,
+                bits.get_bits(L2GroupMetadata::FREE_BITS) + self.free,
+            );
+            new_bits.set_bit(L2GroupMetadata::OWNED_BIT, false);
+            new_bits.set_bits(
+                L2GroupMetadata::L1_ALLOCATED_BITS,
+                u32::from(self.allocated_bitmask.bits),
+            );
+            match metadata
+                .bits
+                .compare_exchange(bits, new_bits, Ordering::SeqCst, Ordering::SeqCst)
+            {
+                Ok(_) => break,
+                Err(new_bits) => bits = new_bits,
+            }
+        }
+    }
+}
+
+struct PhysicalAddressChunk {
+    slot: AtomicCell<SlotIndex>,
+}
+
+impl PhysicalAddressChunk {
+    const fn new() -> Self {
+        Self {
+            slot: AtomicCell::new(SlotIndex::MIN),
+        }
+    }
+}
+
+struct PhysicalAddressGroup {
+    chunks: ChunkArray<PhysicalAddressChunk>,
+}
+
+impl PhysicalAddressGroup {
+    const fn new() -> Self {
+        Self {
+            chunks: [const { PhysicalAddressChunk::new() }; GROUP_SIZE],
+        }
+    }
+}
+
+#[repr(align(64))]
+struct PhysicalAddressSuperGroup {
+    groups: GroupArray<PhysicalAddressGroup>,
+}
+
+impl PhysicalAddressSuperGroup {
+    const fn new() -> Self {
+        Self {
+            groups: [const { PhysicalAddressGroup::new() }; SUPER_GROUP_SIZE],
+        }
+    }
+}
+
+#[repr(align(64))]
+struct ReverseMap {
+    slots: SlotArray<AtomicU16>,
+}
+
+impl ReverseMap {
+    const fn new() -> Self {
+        Self {
+            slots: [const { AtomicU16::new(0) }; SLOTS],
+        }
+    }
+
+    fn get(&self, slot_idx: SlotIndex) -> (GroupIndex, ChunkIndex) {
+        let bits = self.slots[slot_idx].load(Ordering::SeqCst);
+        let chunk_idx = bits.get_bits(0..GROUP_ORDER);
+        let group_idx = bits.get_bits(GROUP_ORDER..GROUP_ORDER + SUPER_GROUP_ORDER);
+        let chunk_idx = ChunkIndex::new(usize::from(chunk_idx));
+        let group_idx = GroupIndex::new(usize::from(group_idx));
+        (group_idx, chunk_idx)
+    }
+
+    fn set(&self, slot_idx: SlotIndex, group_idx: GroupIndex, chunk_idx: ChunkIndex) {
+        let mut bits = 0;
+        bits.set_bits(0..GROUP_ORDER, chunk_idx.get() as u16);
+        bits.set_bits(
+            GROUP_ORDER..GROUP_ORDER + SUPER_GROUP_ORDER,
+            group_idx.get() as u16,
+        );
+        self.slots[slot_idx].store(bits, Ordering::SeqCst);
     }
 }

--- a/tee/kernel/src/memory/heap.rs
+++ b/tee/kernel/src/memory/heap.rs
@@ -2,17 +2,15 @@ use core::alloc::Layout;
 
 use self::{combined_allocator::Combined, huge_allocator::HugeAllocator};
 
-use super::frame::NewAllocator;
-
 mod combined_allocator;
 mod fallback_allocator;
 mod fixed_size_allocator;
 mod huge_allocator;
 
-static HUGE_ALLOCATOR: HugeAllocator<NewAllocator> = HugeAllocator::new(NewAllocator);
+static HUGE_ALLOCATOR: HugeAllocator = HugeAllocator::new();
 
 #[global_allocator]
-static GLOBAL: Combined<&HugeAllocator<NewAllocator>> = Combined::new(&HUGE_ALLOCATOR);
+static GLOBAL: Combined<&HugeAllocator> = Combined::new(&HUGE_ALLOCATOR);
 
 #[alloc_error_handler]
 fn alloc_error_handler(layout: Layout) -> ! {

--- a/tee/kernel/src/memory/heap.rs
+++ b/tee/kernel/src/memory/heap.rs
@@ -2,17 +2,17 @@ use core::alloc::Layout;
 
 use self::{combined_allocator::Combined, huge_allocator::HugeAllocator};
 
-use super::frame::{BitmapFrameAllocator, FRAME_ALLOCATOR};
+use super::frame::NewAllocator;
 
 mod combined_allocator;
 mod fallback_allocator;
 mod fixed_size_allocator;
 mod huge_allocator;
 
-static HUGE_ALLOCATOR: HugeAllocator<&BitmapFrameAllocator> = HugeAllocator::new(&FRAME_ALLOCATOR);
+static HUGE_ALLOCATOR: HugeAllocator<NewAllocator> = HugeAllocator::new(NewAllocator);
 
 #[global_allocator]
-static GLOBAL: Combined<&HugeAllocator<&BitmapFrameAllocator>> = Combined::new(&HUGE_ALLOCATOR);
+static GLOBAL: Combined<&HugeAllocator<NewAllocator>> = Combined::new(&HUGE_ALLOCATOR);
 
 #[alloc_error_handler]
 fn alloc_error_handler(layout: Layout) -> ! {

--- a/tee/kernel/src/memory/heap/fixed_size_allocator.rs
+++ b/tee/kernel/src/memory/heap/fixed_size_allocator.rs
@@ -236,7 +236,7 @@ impl<const N: usize> ChunkHeader<N> {
         crate::sanitize::map_shadow(
             addr as *mut _,
             Size2MiB::SIZE as usize,
-            &mut &crate::memory::heap::FRAME_ALLOCATOR,
+            &mut crate::memory::frame::NewAllocator,
         );
         // Forbid accessing the entries.
         #[cfg(sanitize = "address")]
@@ -300,7 +300,7 @@ impl<const N: usize> ChunkHeader<N> {
         crate::sanitize::unmap_shadow(
             ptr as *mut _,
             Size2MiB::SIZE as usize,
-            &mut &crate::memory::heap::FRAME_ALLOCATOR,
+            &mut crate::memory::frame::NewAllocator,
         );
 
         // Release the physical memory.

--- a/tee/kernel/src/memory/heap/fixed_size_allocator.rs
+++ b/tee/kernel/src/memory/heap/fixed_size_allocator.rs
@@ -233,11 +233,7 @@ impl<const N: usize> ChunkHeader<N> {
 
         // Map shadow memory for the chunk.
         #[cfg(sanitize = "address")]
-        crate::sanitize::map_shadow(
-            addr as *mut _,
-            Size2MiB::SIZE as usize,
-            &mut crate::memory::frame::NewAllocator,
-        );
+        crate::sanitize::map_shadow(addr as *mut _, Size2MiB::SIZE as usize);
         // Forbid accessing the entries.
         #[cfg(sanitize = "address")]
         unsafe {
@@ -297,11 +293,7 @@ impl<const N: usize> ChunkHeader<N> {
 
         // Unmap shadow memory for the chunk.
         #[cfg(sanitize = "address")]
-        crate::sanitize::unmap_shadow(
-            ptr as *mut _,
-            Size2MiB::SIZE as usize,
-            &mut crate::memory::frame::NewAllocator,
-        );
+        crate::sanitize::unmap_shadow(ptr as *mut _, Size2MiB::SIZE as usize);
 
         // Release the physical memory.
         unsafe {

--- a/tee/kernel/src/memory/temporary.rs
+++ b/tee/kernel/src/memory/temporary.rs
@@ -3,10 +3,7 @@ use core::{
     cell::{RefCell, RefMut},
 };
 
-use crate::{
-    memory::frame::NewAllocator,
-    spin::{lazy::Lazy, mutex::Mutex},
-};
+use crate::spin::{lazy::Lazy, mutex::Mutex};
 use constants::{physical_address::DYNAMIC, virtual_address::TEMPORARY};
 use x86_64::structures::paging::{page::PageRangeInclusive, Page, PhysFrame, Size4KiB};
 
@@ -107,7 +104,7 @@ impl TemporaryMapping {
         let entry =
             PresentPageTableEntry::new(frame, PageTableFlags::WRITABLE | PageTableFlags::GLOBAL);
         unsafe {
-            map_page(*page, entry, &mut NewAllocator)?;
+            map_page(*page, entry)?;
         }
 
         Ok(Self { page })

--- a/tee/kernel/src/memory/temporary.rs
+++ b/tee/kernel/src/memory/temporary.rs
@@ -3,16 +3,16 @@ use core::{
     cell::{RefCell, RefMut},
 };
 
-use crate::spin::{lazy::Lazy, mutex::Mutex};
+use crate::{
+    memory::frame::NewAllocator,
+    spin::{lazy::Lazy, mutex::Mutex},
+};
 use constants::{physical_address::DYNAMIC, virtual_address::TEMPORARY};
 use x86_64::structures::paging::{page::PageRangeInclusive, Page, PhysFrame, Size4KiB};
 
 use crate::{
     error::Result,
-    memory::{
-        frame::FRAME_ALLOCATOR,
-        pagetable::{map_page, PresentPageTableEntry},
-    },
+    memory::pagetable::{map_page, PresentPageTableEntry},
     per_cpu::PerCpu,
 };
 
@@ -107,7 +107,7 @@ impl TemporaryMapping {
         let entry =
             PresentPageTableEntry::new(frame, PageTableFlags::WRITABLE | PageTableFlags::GLOBAL);
         unsafe {
-            map_page(*page, entry, &mut (&FRAME_ALLOCATOR))?;
+            map_page(*page, entry, &mut NewAllocator)?;
         }
 
         Ok(Self { page })

--- a/tee/kernel/src/per_cpu.rs
+++ b/tee/kernel/src/per_cpu.rs
@@ -14,7 +14,10 @@ use x86_64::{
 };
 
 use crate::{
-    memory::pagetable::{PagetablesAllocations, ReservedFrameStorage},
+    memory::{
+        frame,
+        pagetable::{PagetablesAllocations, ReservedFrameStorage},
+    },
     user::process::syscall::cpu_state::{KernelRegisters, RawExit, Registers},
 };
 
@@ -39,6 +42,7 @@ pub struct PerCpu {
     pub vector: Cell<u8>,
     pub error_code: Cell<u64>,
     pub last_pagetables: RefCell<Option<Arc<PagetablesAllocations>>>,
+    pub private_allocator_state: RefCell<Option<frame::PrivateState>>,
 }
 
 impl PerCpu {
@@ -59,6 +63,7 @@ impl PerCpu {
             vector: Cell::new(0),
             error_code: Cell::new(0),
             last_pagetables: RefCell::new(None),
+            private_allocator_state: RefCell::new(None),
         }
     }
 

--- a/tee/kernel/src/per_cpu.rs
+++ b/tee/kernel/src/per_cpu.rs
@@ -14,10 +14,7 @@ use x86_64::{
 };
 
 use crate::{
-    memory::{
-        frame,
-        pagetable::{PagetablesAllocations, ReservedFrameStorage},
-    },
+    memory::{frame, pagetable::PagetablesAllocations},
     user::process::syscall::cpu_state::{KernelRegisters, RawExit, Registers},
 };
 
@@ -31,7 +28,6 @@ pub struct PerCpu {
     pub idx: usize,
     pub kernel_registers: Cell<KernelRegisters>,
     pub new_userspace_registers: Cell<Registers>,
-    pub reserved_frame_storage: RefCell<ReservedFrameStorage>,
     pub temporary_mapping: OnceCell<RefCell<Page>>,
     pub tss: OnceCell<TaskStateSegment>,
     pub gdt: OnceCell<GlobalDescriptorTable>,
@@ -52,7 +48,6 @@ impl PerCpu {
             idx: 0,
             kernel_registers: Cell::new(KernelRegisters::ZERO),
             new_userspace_registers: Cell::new(Registers::ZERO),
-            reserved_frame_storage: RefCell::new(ReservedFrameStorage::new()),
             temporary_mapping: OnceCell::new(),
             tss: OnceCell::new(),
             gdt: OnceCell::new(),

--- a/tee/kernel/src/supervisor.rs
+++ b/tee/kernel/src/supervisor.rs
@@ -3,7 +3,7 @@ use core::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use crate::spin::mutex::Mutex;
+use crate::{memory::frame::NewAllocator, spin::mutex::Mutex};
 use arrayvec::ArrayVec;
 use constants::{
     FINISH_OUTPUT_MSR, HALT_PORT, KICK_AP_PORT, MAX_APS_COUNT, MEMORY_MSR, SCHEDULE_PORT,
@@ -16,10 +16,7 @@ use x86_64::{
     PhysAddr,
 };
 
-use crate::{
-    memory::{frame::FRAME_ALLOCATOR, temporary::copy_into_frame},
-    per_cpu::PerCpu,
-};
+use crate::{memory::temporary::copy_into_frame, per_cpu::PerCpu};
 
 pub static ALLOCATOR: Allocator = Allocator::new();
 
@@ -156,7 +153,7 @@ pub fn launch_next_ap() {
 
 pub fn output(bytes: &[u8]) {
     static FRAME: Mutex<LazyCell<PhysFrame>> = Mutex::new(LazyCell::new(|| {
-        (&FRAME_ALLOCATOR)
+        NewAllocator
             .allocate_frame()
             .expect("failed to allocate frame for output")
     }));

--- a/tee/kernel/src/supervisor.rs
+++ b/tee/kernel/src/supervisor.rs
@@ -3,7 +3,7 @@ use core::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use crate::{memory::frame::NewAllocator, spin::mutex::Mutex};
+use crate::{memory::frame::allocate_frame, spin::mutex::Mutex};
 use arrayvec::ArrayVec;
 use constants::{
     FINISH_OUTPUT_MSR, HALT_PORT, KICK_AP_PORT, MAX_APS_COUNT, MEMORY_MSR, SCHEDULE_PORT,
@@ -152,11 +152,7 @@ pub fn launch_next_ap() {
 }
 
 pub fn output(bytes: &[u8]) {
-    static FRAME: Mutex<LazyCell<PhysFrame>> = Mutex::new(LazyCell::new(|| {
-        NewAllocator
-            .allocate_frame()
-            .expect("failed to allocate frame for output")
-    }));
+    static FRAME: Mutex<LazyCell<PhysFrame>> = Mutex::new(LazyCell::new(allocate_frame));
 
     let guard = FRAME.lock();
     let frame = **guard;

--- a/tee/kernel/src/user.rs
+++ b/tee/kernel/src/user.rs
@@ -1,4 +1,4 @@
-use crate::{rt::poll, supervisor::halt, time::advance_time};
+use crate::{memory::frame, rt::poll, supervisor::halt, time::advance_time};
 
 pub mod process;
 
@@ -14,6 +14,10 @@ pub fn run() -> ! {
         if !should_halt {
             continue;
         }
+
+        // Halt the vCPU.
+
+        frame::release_private();
 
         let res = halt();
         if res.is_err() {

--- a/tee/kernel/src/user/process/memory.rs
+++ b/tee/kernel/src/user/process/memory.rs
@@ -14,6 +14,7 @@ use crate::{
     error::{ensure, err},
     fs::{fd::FileDescriptor, path::Path},
     memory::{
+        frame::NewAllocator,
         page::{KernelPage, UserPage},
         pagetable::{check_user_address, Pagetables},
     },
@@ -42,7 +43,7 @@ use x86_64::{
 
 use crate::{
     error::{Error, Result},
-    memory::{frame::FRAME_ALLOCATOR, pagetable::PageTableFlags},
+    memory::pagetable::PageTableFlags,
 };
 
 use super::syscall::{
@@ -165,7 +166,7 @@ impl VirtualMemory {
         }
 
         self.pagetables
-            .set_page(page, entry, &mut &FRAME_ALLOCATOR)
+            .set_page(page, entry, &mut NewAllocator)
             .map_err(PageFaultError::Other)?;
 
         Ok(())

--- a/tee/kernel/src/user/process/memory.rs
+++ b/tee/kernel/src/user/process/memory.rs
@@ -14,7 +14,6 @@ use crate::{
     error::{ensure, err},
     fs::{fd::FileDescriptor, path::Path},
     memory::{
-        frame::NewAllocator,
         page::{KernelPage, UserPage},
         pagetable::{check_user_address, Pagetables},
     },
@@ -166,7 +165,7 @@ impl VirtualMemory {
         }
 
         self.pagetables
-            .set_page(page, entry, &mut NewAllocator)
+            .set_page(page, entry)
             .map_err(PageFaultError::Other)?;
 
         Ok(())


### PR DESCRIPTION
The old physical memory allocator had very bad performance (especially when multiple threads would try to allocate at once). The new physical memory allocator was inspired by LLFree.