### PR TITLE
tell rust-analyzer to use cargo hack

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "rust-analyzer.cargo.allTargets": false,
+    "rust-analyzer.check.overrideCommand": [
+        "cargo",
+        "hack",
+        "clippy",
+        "--message-format=json-diagnostic-rendered-ansi"
+    ],
+}


### PR DESCRIPTION
This helps resolve feature unification issues where some targets use std and some don't.