### PR TITLE
make it possible to supply multiple inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ It should be impossible for the attacker to tamper with any of these without the
 
 There is no way for the workloads to communicate with the host, external devices or external services. The only input to the workload is the input file provided to it.
 
+More details can be found [here](docs/attestation.md).
+
 ### Non-goals
 
 The workload kernel has not been hardened against attacks from within the workload itself, only the outputs of trusted workloads and inputs should be considered trusted. 

--- a/common/io/src/input.rs
+++ b/common/io/src/input.rs
@@ -1,19 +1,42 @@
-use bytemuck::{bytes_of, Pod, Zeroable};
-use sha2::{Digest, Sha256};
+use bytemuck::{bytes_of, CheckedBitPattern, NoUninit};
+use sha2::{Digest, Sha256, Sha384};
 
-#[derive(Debug, Clone, Copy, Pod, Zeroable)]
+pub const MAX_HASH_SIZE: usize = 48;
+
+#[derive(Debug, Clone, Copy, CheckedBitPattern, NoUninit, PartialEq, Eq)]
 #[repr(C)]
 pub struct Header {
-    pub input_len: usize,
-    pub hash: [u8; 32],
+    pub input_len: u64,
+    pub hash_type: HashType,
+    pub hash: [u8; MAX_HASH_SIZE],
+    pub next_hash: [u8; 32],
 }
 
 impl Header {
-    pub fn new(bytes: &[u8]) -> Self {
-        let hash = Sha256::digest(bytes);
+    pub fn new(bytes: &[u8], hash_type: HashType, next: &Self) -> Self {
         Self {
-            input_len: bytes.len(),
-            hash: <[u8; 32]>::from(hash),
+            input_len: bytes.len() as u64,
+            hash_type,
+            hash: hash_type.hash(bytes),
+            next_hash: next.hash(),
+        }
+    }
+
+    pub fn without_hash(bytes: &[u8]) -> Self {
+        Self {
+            input_len: bytes.len() as u64,
+            hash_type: HashType::Sha256,
+            hash: [0; MAX_HASH_SIZE],
+            next_hash: [0; 32],
+        }
+    }
+
+    pub const fn end() -> Self {
+        Self {
+            input_len: !0,
+            hash_type: HashType::Sha256,
+            hash: [0; MAX_HASH_SIZE],
+            next_hash: [0; 32],
         }
     }
 
@@ -23,5 +46,54 @@ impl Header {
 
     pub fn verify(&self, hash: [u8; 32]) -> bool {
         self.hash() == hash
+    }
+}
+
+#[derive(Debug, Clone, Copy, CheckedBitPattern, NoUninit, PartialEq, Eq, Default)]
+#[repr(u64)]
+pub enum HashType {
+    #[default]
+    Sha256,
+    Sha384,
+}
+
+impl HashType {
+    pub fn hash(self, data: &[u8]) -> [u8; MAX_HASH_SIZE] {
+        let mut hash = [0; MAX_HASH_SIZE];
+        match self {
+            HashType::Sha256 => hash[..32].copy_from_slice(&Sha256::digest(data)),
+            HashType::Sha384 => hash[..48].copy_from_slice(&Sha384::digest(data)),
+        }
+        hash
+    }
+}
+
+pub enum Hasher {
+    Sha256(Sha256),
+    Sha384(Sha384),
+}
+
+impl Hasher {
+    pub fn new(hash_type: HashType) -> Self {
+        match hash_type {
+            HashType::Sha256 => Self::Sha256(Sha256::new()),
+            HashType::Sha384 => Self::Sha384(Sha384::new()),
+        }
+    }
+
+    pub fn update(&mut self, data: &[u8]) {
+        match self {
+            Hasher::Sha256(hasher) => hasher.update(data),
+            Hasher::Sha384(hasher) => hasher.update(data),
+        }
+    }
+
+    pub fn verify(self, hash: [u8; MAX_HASH_SIZE]) {
+        let mut bytes = [0; MAX_HASH_SIZE];
+        match self {
+            Hasher::Sha256(hasher) => bytes[..32].copy_from_slice(&hasher.finalize()),
+            Hasher::Sha384(hasher) => bytes[..48].copy_from_slice(&hasher.finalize()),
+        }
+        assert_eq!(hash, bytes, "input hash doesn't match hash in header");
     }
 }

--- a/common/loader/src/input.rs
+++ b/common/loader/src/input.rs
@@ -2,25 +2,52 @@ use std::{iter::once, mem::size_of};
 
 use bytemuck::bytes_of;
 use constants::physical_address::INPUT_FILE;
-use io::input::Header;
+use io::input::{HashType, Header};
 use snp_types::VmplPermissions;
 use x86_64::structures::paging::PhysFrame;
 
 use crate::{LoadCommand, LoadCommandPayload};
 
-pub fn load_input(input: &[u8]) -> (impl Iterator<Item = LoadCommand> + '_, [u8; 32]) {
-    let header = Header::new(input);
+pub struct Input<T> {
+    pub bytes: T,
+    pub hash_type: HashType,
+}
 
-    let payloads = once(LoadCommandPayload::Shared({
-        let mut bytes = [0; 0x1000];
-        bytes[..size_of::<Header>()].copy_from_slice(bytes_of(&header));
-        bytes
-    }))
-    .chain(input.chunks(0x1000).map(|chunk| {
-        let mut bytes = [0; 0x1000];
-        bytes[..chunk.len()].copy_from_slice(chunk);
-        LoadCommandPayload::Shared(bytes)
-    }));
+pub fn load_input(
+    inputs: &[Input<impl AsRef<[u8]>>],
+) -> (impl Iterator<Item = LoadCommand> + '_, [u8; 32]) {
+    let mut header = Header::end();
+    let mut headers = inputs
+        .iter()
+        .rev()
+        .map(|input| {
+            header = Header::new(input.bytes.as_ref(), input.hash_type, &header);
+            header
+        })
+        .collect::<Vec<_>>();
+    headers.reverse();
+
+    let payloads = headers
+        .into_iter()
+        .zip(inputs)
+        .flat_map(|(header, input)| {
+            once(LoadCommandPayload::Shared({
+                let mut bytes = [0; 0x1000];
+                bytes[..size_of::<Header>()].copy_from_slice(bytes_of(&header));
+                bytes
+            }))
+            .chain(input.bytes.as_ref().chunks(0x1000).map(|chunk| {
+                let mut bytes = [0; 0x1000];
+                bytes[..chunk.len()].copy_from_slice(chunk);
+                LoadCommandPayload::Shared(bytes)
+            }))
+        })
+        .chain(once(LoadCommandPayload::Shared({
+            let header = Header::end();
+            let mut bytes = [0; 0x1000];
+            bytes[..size_of::<Header>()].copy_from_slice(bytes_of(&header));
+            bytes
+        })));
 
     let start_frame = PhysFrame::from_start_address(INPUT_FILE.start.start_address()).unwrap();
     let end_frame = PhysFrame::from_start_address(INPUT_FILE.end.start_address()).unwrap();

--- a/common/loader/src/lib.rs
+++ b/common/loader/src/lib.rs
@@ -10,6 +10,9 @@ mod input;
 mod kernel;
 mod supervisor;
 
+pub use input::Input;
+pub use io::input::HashType;
+
 #[derive(Debug)]
 pub struct LoadCommand {
     pub physical_address: PhysFrame,
@@ -69,10 +72,10 @@ pub fn generate_load_commands<'a>(
     kernel: &'a [u8],
     init: &'a [u8],
     load_kasan_shadow_mappings: bool,
-    input: &'a [u8],
+    inputs: &'a [Input<impl AsRef<[u8]>>],
 ) -> (impl Iterator<Item = LoadCommand> + 'a, [u8; 32]) {
     let base_load_commands =
         generate_base_load_commands(supervisor, kernel, init, load_kasan_shadow_mappings);
-    let (load_input, host_data) = input::load_input(input);
+    let (load_input, host_data) = input::load_input(inputs);
     (base_load_commands.chain(load_input), host_data)
 }

--- a/docs/attestation.md
+++ b/docs/attestation.md
@@ -1,0 +1,113 @@
+# Attestation
+
+Attestation is used to prove that a certain set of supervisor, kernel, workload init binary, and workload input were used to produce a certain output.
+If any binary or input is changed, the change will be visible in the attestation report.
+Notably, this includes malicious workload inputs:
+Even if a malicious input manages to exploit the workload, it is impossible for the exploit to generate an attestation report that doesn't include the malicious workload input.
+Attestation reports are signed by the hardware root of trust.
+
+## Hardware-measured input memory
+
+The supervisor, the kernel, and the workload init binary are added directly to the initial guest memory during launch.
+On AMD SEV-SNP, this memory is added using `SNP_LAUNCH_UPDATE`.
+On Intel TDX, this memory is added using `MEM.PAGE.ADD` and `MR.EXTEND`.
+
+The hardware derives a launch measurement from the initial guest memory.
+This launch measurement never changes unless the supervisor, the kernel, or the init binary changes.
+On AMD SEV-SNP, the launch measurement is stored in the `MEASUREMENT` field in the attestation report.
+On Intel TDX, the launch measurement is stored in the `MRTD` field in the TD quote.
+The launch measurement is independent of the workload input and output.
+
+`mushroom verify` computes the launch measurement for a given supervisor, kernel, and workload init binary and verifies that it matches the value in the attestation report.
+
+#### Details
+
+The initial memory is assembled by [`loader`](../common/loader/) sub-crate.
+We use special linker scripts for the supervisor and kernel that explicitly specify physical addresses for all segments.
+The loader parses the ELF binaries and generates load commands for each segment at the specified physical addresses.
+On AMD SEV-SNP, the loader uses the segment permissions in the kernel binary as the VMPL 1 permissions used in `SNP_LAUNCH_UPDATE`.
+On Intel TDX, the loader cannot add permissions for the L2 VM, so this is done by the supervisor during boot.
+
+## Supervisor-measured input memory
+
+The workload input is measured and verified by the supervisor before the workload is started.
+
+The workload input is initially stored in unmeasured shared memory.
+As the supervisor reads and verifies the input, it converts it into private memory.
+The supervisor never interprets the input in any way, it only passes it forward to the workload kernel.
+
+The supervisor verifies that the input matches a hypervisor-supplied hash.
+This hash is also part of the attestation report.
+Because the hash is part of the attestation report, this hypervisor can't change the input hash without this being visible in the attestation report, so the hash isn't considered an untrusted input even though it's supplied by the hypervisor.
+On AMD SEV-SNP, the input hash is stored in the `HOST_DATA` field in the attestation report.
+On Intel TDX, the input hash is stored in the first 32 bytes of the `MRCONFIGID` field in the TD quote.
+
+`mushroom verify` computes the hash for a given input and verifies that it matches the value in the attestation report.
+
+#### Details
+
+Mushroom allows the input to be split up into multiple chunks.
+Chunks are placed one after another in memory.
+
+Each input chunk is preceded by a header containing the chunk length, its hash, the hash type, and the hash of the next chunk header:
+```rust
+#[repr(C)]
+pub struct Header {
+    pub input_len: u64,
+    pub hash_type: HashType,
+    pub hash: [u8; MAX_HASH_SIZE],
+    pub next_hash: [u8; 32],
+}
+```
+The first header is verified by hashing it with SHA-256 and comparing the digest to the hash in the attestation report (`HOST_DATA` or `MRCONFIGID`).
+The following header(s) are verified by hashing it with SHA-256 and comparing the digest to the `next_hash` in the previous header.
+Note that `hash` contains the digest of the chunk content whereas `next_hash` contains the digest of the next chunk header (**not** the next chunk content).
+Because each chunk header contains the digest of the next chunk header and is therefore dependent on its content, the hashes have to be calculated from back to front, but the supervisor can verify the hashes from front to back.
+
+The last chunk is marked with `input_len` being equal to `0xffff_ffff_ffff_ffff`.
+
+### Why isn't the workload input measured as part of the launch measurement?
+
+1. Separation of concerns: mushroom is designed for use cases where the relying party will verify many attestation reports for the same workload with different inputs.
+   Separating the workload from its input simplifies the computations needed to verify attestation reports.
+2. Performance: Adding memory to the launch measurement is fairly slow on AMD SEV-SNP.
+   A large input could cause significant performance problems.
+
+## Output
+
+The workload output is hashed using SHA-256 and its digest placed into the attestation report.
+The output size is also placed into the attestation report.
+On AMD SEV-SNP, the output digest and size are placed in the `REPORT_DATA` field in the attestation report.
+On Intel TDX, the output digest and size are placed in the `REPORTDATA` field in the TD quote.
+
+Note that on both AMD SEV-SNP and Intel TDX, the `REPORT_DATA` and `REPORTDATA` fields are the only fields that can be influenced by the workload at runtime.
+The workload cannot influence any other fields including the `MEASUREMENT`, `MRTD`, `HOST_DATA`, and `MRCONFIGID` fields as all of these are protected by the hardware.
+If a malicous party were to change the supervisor, kernel, workload init binary or workload input that in such a way that it gains code execution within workload, the hardware will prevent the attacker from creating attestation reports that don't reflect the changed binaries/input.
+
+`mushroom verify` computes the hash for a given output and verifies that the digest and output size match the values in the attestation report.
+
+## Attestation report formats
+
+### AMD SEV-SNP
+
+On AMD SEV-SNP, the attestation report returned by mushroom contains an attestation report created by the hardware concatenated with the VCEK certificate that proves that the attestation report was generated by real hardware.
+`mushroom verify` checks that the public key in the VCEK matches the signature in the attestation report and checks that the VCEK was signed by one of the built-in ASKs [^1].
+
+[^1]: https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/specifications/57230.pdf
+
+### Intel TDX
+
+On Intel TDX, the attestation report is just a normal TD quote version 4 [^2].
+
+Note that the supervisor outputs a TD report, not a TD quote.
+It's the responsibility of the mushroom VMM to talk to the quote generation service running on the host to turn the TD report into a full TD quote.
+This doesn't need to be done inside the TD guest.
+
+[^2]: https://download.01.org/intel-sgx/latest/dcap-latest/linux/docs/Intel_TDX_DCAP_Quoting_Library_API.pdf
+
+## Policies & SVNs
+
+Mushroom verifies the trustworthiness of the TEE hardware/firmware by checking the policies and SVNs in attestation reports.
+The mushroom CLI uses reasonable defaults for policies.
+The default SVN minimums match the latest available SVNs at the time the mushroom is compiled, but these may become outdated when new TEE firmwares are released.
+Library users have to specify their own allowed policy flags and minimum SVNs.

--- a/host/mushroom-verify/Cargo.toml
+++ b/host/mushroom-verify/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 bytemuck = { version = "1.15.0", features = ["derive", "min_const_generics"], optional = true }
-loader = { workspace = true, optional = true }
+loader = { workspace = true }
 io = { workspace = true }
 p384 = { version = "0.13.0", optional = true }
 sha2 = "0.10.8"
@@ -16,5 +16,5 @@ x86_64 = { version = "0.15.1", default-features = false, optional = true }
 
 [features]
 default = ["snp", "tdx"]
-snp = ["dep:bytemuck", "dep:p384", "dep:loader", "dep:snp-types", "dep:vcek-kds"]
-tdx = ["dep:loader", "dep:tdx-types", "dep:x86_64"]
+snp = ["dep:bytemuck", "dep:p384", "dep:snp-types", "dep:vcek-kds"]
+tdx = ["dep:tdx-types", "dep:x86_64"]

--- a/host/mushroom-verify/src/lib.rs
+++ b/host/mushroom-verify/src/lib.rs
@@ -49,20 +49,36 @@ impl Configuration {
         )))
     }
 
+    /// Verify that a input with the given hash is attested to have produced an
+    /// output with the given hash.
     pub fn verify(
         &self,
         input_hash: InputHash,
         output_hash: OutputHash,
         attestation_report: &[u8],
     ) -> Result<(), VerificationError> {
+        let hash = self.verify_and_extract(input_hash, attestation_report)?;
+        if hash != output_hash {
+            return Err(VerificationError(()));
+        }
+        Ok(())
+    }
+
+    /// Verify that a input with the given hash is attested to have produced an
+    /// output and return its hash.
+    pub fn verify_and_extract(
+        &self,
+        input_hash: InputHash,
+        attestation_report: &[u8],
+    ) -> Result<OutputHash, VerificationError> {
         match self.0 {
             #[cfg(feature = "snp")]
             ConfigurationImpl::Snp(ref configuration) => {
-                configuration.verify(input_hash, output_hash, attestation_report)
+                configuration.verify_and_extract(input_hash, attestation_report)
             }
             #[cfg(feature = "tdx")]
             ConfigurationImpl::Tdx(ref configuration) => {
-                configuration.verify(input_hash, output_hash, attestation_report)
+                configuration.verify_and_extract(input_hash, attestation_report)
             }
         }
     }

--- a/host/mushroom-verify/src/tdx.rs
+++ b/host/mushroom-verify/src/tdx.rs
@@ -63,12 +63,12 @@ impl Configuration {
         }
     }
 
-    pub fn verify(
+    /// Verify that a input with the given hash is attested to have produced an output and return its hash.
+    pub fn verify_and_extract(
         &self,
         input_hash: InputHash,
-        output_hash: OutputHash,
         attestation_report: &[u8],
-    ) -> Result<(), VerificationError> {
+    ) -> Result<OutputHash, VerificationError> {
         let quote = Quote::parse(attestation_report).map_err(|_| VerificationError(()))?;
         quote
             .verify_signatures()
@@ -103,12 +103,14 @@ impl Configuration {
         verify_eq!(quote.body.mr_owner, [0; 48]);
         verify_eq!(quote.body.mr_owner_config, [0; 48]);
         verify_eq!(quote.body.rtmrs, [[0; 48]; 4]);
-        verify_eq!(quote.body.report_data[..32], output_hash.0);
-        verify_eq!(quote.body.report_data[32..], [0; 32]);
+        verify_eq!(quote.body.report_data[40..], [0; 24]);
 
         // TODO: verify cpu_svn.
 
-        Ok(())
+        Ok(OutputHash {
+            hash: quote.body.report_data[..32].try_into().unwrap(),
+            len: u64::from_le_bytes(quote.body.report_data[32..40].try_into().unwrap()),
+        })
     }
 }
 

--- a/host/mushroom/Cargo.toml
+++ b/host/mushroom/Cargo.toml
@@ -8,10 +8,10 @@ name = "mushroom"
 required-features = ["bin"]
 
 [features]
-default = ["insecure", "snp", "tdx"]
-insecure = ["dep:loader", "dep:snp-types", "dep:supervisor-services"]
-snp = ["dep:loader", "mushroom-verify?/snp", "dep:snp-types", "dep:vcek-kds"]
-tdx = ["dep:loader", "mushroom-verify?/tdx", "dep:qgs-client", "dep:tdx-types"]
+default = ["insecure", "snp", "tdx", "bin"]
+insecure = ["dep:snp-types", "dep:supervisor-services"]
+snp = ["mushroom-verify?/snp", "dep:snp-types", "dep:vcek-kds"]
+tdx = ["mushroom-verify?/tdx", "dep:qgs-client", "dep:tdx-types"]
 bin = ["dep:clap", "dep:mushroom-verify", "dep:tokio", "dep:tracing-subscriber", "dep:xdg"]
 
 [dependencies]
@@ -21,7 +21,7 @@ bitflags = { version = "2.4.2", features = ["bytemuck"] }
 bytemuck = { version = "1.15.0", features = ["derive", "min_const_generics", "extern_crate_std"] }
 clap = { version = "4.5.2", features = ["derive", "env"], optional = true }
 constants = { workspace = true }
-loader = { workspace = true, optional = true }
+loader = { workspace = true }
 log-types = { workspace = true, features = ["std"] }
 mushroom-verify = { workspace = true, optional = true }
 nix = { version = "0.28.0", features = ["fs", "ioctl", "mman", "pthread", "signal"] }

--- a/host/mushroom/src/insecure.rs
+++ b/host/mushroom/src/insecure.rs
@@ -14,6 +14,7 @@ use constants::{
     physical_address::{kernel, supervisor, DYNAMIC_2MIB, SUPERVISOR_SERVICES},
     FIRST_AP, MAX_APS_COUNT,
 };
+use loader::Input;
 use snp_types::PageType;
 use supervisor_services::{
     allocation_buffer::{AllocationBuffer, SlotIndex},
@@ -41,7 +42,7 @@ pub fn main(
     kernel: &[u8],
     init: &[u8],
     load_kasan_shadow_mappings: bool,
-    input: &[u8],
+    inputs: &[Input<impl AsRef<[u8]>>],
 ) -> Result<MushroomResult> {
     let mut cpuid_entries = kvm_handle.get_supported_cpuid()?;
     let piafb = cpuid_entries
@@ -76,7 +77,7 @@ pub fn main(
     vm.set_tsc_khz(TSC_MHZ * 1000)?;
 
     let (load_commands, _host_data) =
-        loader::generate_load_commands(None, kernel, init, load_kasan_shadow_mappings, input);
+        loader::generate_load_commands(None, kernel, init, load_kasan_shadow_mappings, inputs);
     let mut load_commands = load_commands.peekable();
 
     let mut num_launch_pages = 0;

--- a/host/mushroom/src/snp.rs
+++ b/host/mushroom/src/snp.rs
@@ -12,6 +12,7 @@ use constants::{
     physical_address::{kernel, supervisor, DYNAMIC_2MIB},
     FINISH_OUTPUT_MSR, FIRST_AP, KICK_AP_PORT, MAX_APS_COUNT, MEMORY_PORT, UPDATE_OUTPUT_MSR,
 };
+use loader::Input;
 use snp_types::{guest_policy::GuestPolicy, PageType};
 use tracing::{debug, info};
 use vcek_kds::Vcek;
@@ -40,7 +41,7 @@ pub fn main(
     kernel: &[u8],
     init: &[u8],
     load_kasan_shadow_mappings: bool,
-    input: &[u8],
+    inputs: &[Input<impl AsRef<[u8]>>],
     policy: GuestPolicy,
     vcek: Vcek,
     profiler_folder: Option<ProfileFolder>,
@@ -51,7 +52,7 @@ pub fn main(
         supervisor,
         kernel,
         init,
-        input,
+        inputs,
         load_kasan_shadow_mappings,
         policy,
         kvm_handle,
@@ -78,7 +79,7 @@ impl VmContext {
         supervisor: &[u8],
         kernel: &[u8],
         init: &[u8],
-        input: &[u8],
+        inputs: &[Input<impl AsRef<[u8]>>],
         load_kasan_shadow_mappings: bool,
         policy: GuestPolicy,
         kvm_handle: &KvmHandle,
@@ -116,7 +117,7 @@ impl VmContext {
             kernel,
             init,
             load_kasan_shadow_mappings,
-            input,
+            inputs,
         );
         let mut load_commands = load_commands.peekable();
 

--- a/host/mushroom/src/tdx.rs
+++ b/host/mushroom/src/tdx.rs
@@ -17,6 +17,7 @@ use constants::{
     physical_address::{kernel, supervisor, DYNAMIC_2MIB},
     FINISH_OUTPUT_MSR, MAX_APS_COUNT, MEMORY_PORT, UPDATE_OUTPUT_MSR,
 };
+use loader::Input;
 use nix::sys::{
     pthread::pthread_kill,
     signal::{sigaction, SaFlags, SigAction, SigHandler, SigSet, Signal},
@@ -50,7 +51,7 @@ pub fn main(
     kernel: &[u8],
     init: &[u8],
     load_kasan_shadow_mappings: bool,
-    input: &[u8],
+    inputs: &[Input<impl AsRef<[u8]>>],
     profiler_folder: Option<ProfileFolder>,
     cid: u32,
     port: u32,
@@ -60,7 +61,7 @@ pub fn main(
         supervisor,
         kernel,
         init,
-        input,
+        inputs,
         load_kasan_shadow_mappings,
         kvm_handle,
         profiler_folder,
@@ -124,7 +125,7 @@ impl VmContext {
         supervisor: &[u8],
         kernel: &[u8],
         init: &[u8],
-        input: &[u8],
+        inputs: &[Input<impl AsRef<[u8]>>],
         load_kasan_shadow_mappings: bool,
         kvm_handle: &KvmHandle,
         profiler_folder: Option<ProfileFolder>,
@@ -176,7 +177,7 @@ impl VmContext {
             kernel,
             init,
             load_kasan_shadow_mappings,
-            input,
+            inputs,
         );
         let mut load_commands = load_commands.peekable();
 

--- a/tee/supervisor-snp/src/input.rs
+++ b/tee/supervisor-snp/src/input.rs
@@ -1,10 +1,9 @@
 use core::mem::size_of;
 
-use bytemuck::pod_read_unaligned;
+use bytemuck::checked::pod_read_unaligned;
 use constants::physical_address::INPUT_FILE;
-use io::input::Header;
+use io::input::{Hasher, Header};
 use log::info;
-use sha2::{Digest, Sha256};
 use snp_types::{ghcb::msr_protocol::PageOperation, VmplPermissions};
 use x86_64::{
     structures::paging::{Page, PhysFrame, Size4KiB},
@@ -18,42 +17,52 @@ use crate::{
 
 /// Verify the input and make it accessible to VMPL 1.
 pub fn verify_and_load() {
-    // Read the input header.
-    let header_page_bytes = convert_to_private_in_place(0);
-    let header_bytes = &header_page_bytes[..size_of::<Header>()];
-    let header = pod_read_unaligned::<Header>(header_bytes);
+    let mut page_index = 0;
 
-    // Verify the input header.
-    let host_data = get_host_data();
-    assert!(header.verify(host_data), "header doesn't match host data");
-
-    // Hash the input.
-
-    let mut hasher = Sha256::new();
-
-    // Copy pages one at a time.
-    let mut page_index = 1;
-    let mut remaining_len = header.input_len;
-    while remaining_len >= 0x1000 {
-        let input_bytes = convert_to_private_in_place(page_index);
-        hasher.update(input_bytes);
-        remaining_len -= 0x1000;
+    let mut next_hash = get_host_data();
+    loop {
+        // Read the input header.
+        let header_page_bytes = convert_to_private_in_place(page_index);
+        let header_bytes = &header_page_bytes[..size_of::<Header>()];
+        let header = pod_read_unaligned::<Header>(header_bytes);
         page_index += 1;
+
+        // Verify the input header.
+        assert!(header.verify(next_hash), "header doesn't match");
+
+        if header == Header::end() {
+            break;
+        }
+
+        // Hash the input.
+
+        let mut hasher = Hasher::new(header.hash_type);
+
+        // Copy pages one at a time.
+        let mut remaining_len = usize::try_from(header.input_len).unwrap();
+        while remaining_len >= 0x1000 {
+            let input_bytes = convert_to_private_in_place(page_index);
+            page_index += 1;
+            hasher.update(&input_bytes);
+            remaining_len -= 0x1000;
+        }
+
+        // The last page may not be a full page.
+        if remaining_len > 0 {
+            let input_bytes = convert_to_private_in_place(page_index);
+            page_index += 1;
+            let (input_bytes, rest) = input_bytes.split_at(remaining_len);
+            hasher.update(input_bytes);
+
+            // The page must be zero past the end of the input.
+            assert_eq!(rest, &[0; 4096][remaining_len..]);
+        }
+
+        // Verify the input.
+        hasher.verify(header.hash);
+
+        next_hash = header.next_hash;
     }
-
-    // The last page may not be a full page.
-    if remaining_len > 0 {
-        let input_bytes = convert_to_private_in_place(page_index);
-        let (input_bytes, rest) = input_bytes.split_at(remaining_len);
-        hasher.update(input_bytes);
-
-        // The page must be zero past the end of the input.
-        assert_eq!(rest, &[0; 4096][remaining_len..]);
-    }
-
-    // Verify the input.
-    let hash: [u8; 32] = hasher.finalize().into();
-    assert_eq!(header.hash, hash, "input hash doesn't match hash in header");
 
     info!("verified input");
 }

--- a/tee/supervisor-tdx/src/output.rs
+++ b/tee/supervisor-tdx/src/output.rs
@@ -11,9 +11,26 @@ use crate::{
     tdcall::{Tdcall, Vmcall},
 };
 
+#[derive(Default)]
+struct Hasher {
+    sha256: Sha256,
+    len: usize,
+}
+
+impl Hasher {
+    pub fn update(&mut self, bytes: &[u8]) {
+        self.sha256.update(bytes);
+        self.len += bytes.len();
+    }
+
+    pub fn finalize(self) -> ([u8; 32], usize) {
+        (self.sha256.finalize().into(), self.len)
+    }
+}
+
 /// This hasher is used to calculate the hash of the output that's included in
 /// the attestation report.
-static HASHER: Lazy<Mutex<Option<Sha256>>> = Lazy::new(|| Mutex::new(Some(Sha256::default())));
+static HASHER: Lazy<Mutex<Option<Hasher>>> = Lazy::new(|| Mutex::new(Some(Hasher::default())));
 
 /// Append some bytes to the output.
 pub fn update_output(bytes: &[u8]) {
@@ -46,12 +63,12 @@ pub fn finish() -> ! {
     // Finish the running hash.
     let mut guard = HASHER.lock();
     let hasher = guard.take().expect("hasher was already finished");
-    let result = hasher.finalize();
-    let output: [u8; 32] = result.into();
+    let (hash, len) = hasher.finalize();
 
     // Create the attestation report.
     let mut report_data = [0; 64];
-    report_data[..32].copy_from_slice(&output);
+    report_data[..32].copy_from_slice(&hash);
+    report_data[32..40].copy_from_slice(&len.to_le_bytes());
 
     let attestation_report = Tdcall::mr_report(report_data);
 


### PR DESCRIPTION
The key difference between having multiple smaller inputs vs one larger input is that every smaller input is hashed separately as opposed to one hash over the entire input. This makes it possible to easily append to inputs without having to calculate the hash over the entire input. This is very useful in scenarios where a verifier doesn't know an input, but knows its hash. With these changes, it's possible for a verifier to verify an attestation report with multiple such inputs.