### PR TITLE
raise the soft limit for file descriptors

### DIFF
--- a/host/mushroom/Cargo.toml
+++ b/host/mushroom/Cargo.toml
@@ -24,7 +24,7 @@ constants = { workspace = true }
 loader = { workspace = true }
 log-types = { workspace = true, features = ["std"] }
 mushroom-verify = { workspace = true, optional = true }
-nix = { version = "0.29.0", features = ["fs", "ioctl", "mman", "pthread", "signal"] }
+nix = { version = "0.29.0", features = ["fs", "ioctl", "mman", "pthread", "resource", "signal"] }
 profiler-types = { workspace = true }
 qgs-client = { workspace = true, optional = true }
 rand = "0.8.5"

--- a/host/mushroom/src/snp.rs
+++ b/host/mushroom/src/snp.rs
@@ -35,6 +35,7 @@ use crate::{
     },
     logging::start_log_collection,
     profiler::{start_profile_collection, ProfileFolder},
+    raise_file_no_limit,
     slot::Slot,
     MushroomResult, SIG_KICK,
 };
@@ -229,6 +230,7 @@ impl VmContext {
         }
 
         install_signal_handler();
+        raise_file_no_limit();
 
         Ok(Self {
             vm,

--- a/host/mushroom/src/tdx.rs
+++ b/host/mushroom/src/tdx.rs
@@ -34,6 +34,7 @@ use crate::{
     },
     logging::start_log_collection,
     profiler::{start_profile_collection, ProfileFolder},
+    raise_file_no_limit,
     slot::Slot,
     MushroomResult, SIG_KICK, TSC_MHZ,
 };
@@ -255,6 +256,7 @@ impl VmContext {
         }
 
         install_signal_handler();
+        raise_file_no_limit();
 
         Ok((
             Self {


### PR DESCRIPTION
If we don't do this, we quickly run into the limit when trying to create memfds.