### PR TITLE
unmap KVM run block

### DIFF
--- a/host/mushroom/src/insecure.rs
+++ b/host/mushroom/src/insecure.rs
@@ -236,6 +236,7 @@ fn run_kernel_vcpu(
         ap.set_cpuid(&cpuid_entries).unwrap();
 
         let kvm_run = ap.get_kvm_run_block().unwrap();
+        let kvm_run = kvm_run.as_ptr();
 
         let mut sregs = ap.get_sregs().unwrap();
         sregs.es = KvmSegment::DATA64;

--- a/host/mushroom/src/snp.rs
+++ b/host/mushroom/src/snp.rs
@@ -248,6 +248,7 @@ impl VmContext {
     pub fn run_supervisor(&mut self) -> Result<MushroomResult> {
         let mut output = Vec::new();
         let kvm_run = self.bsp.get_kvm_run_block()?;
+        let kvm_run = kvm_run.as_ptr();
 
         loop {
             let exit = kvm_run.read().exit();
@@ -414,6 +415,7 @@ impl VmContext {
             ap.set_msr(DEBUG_CTL, 1).unwrap();
 
             let kvm_run = ap.get_kvm_run_block().unwrap();
+            let kvm_run = kvm_run.as_ptr();
 
             std::thread::park();
 

--- a/host/mushroom/src/tdx.rs
+++ b/host/mushroom/src/tdx.rs
@@ -281,6 +281,7 @@ impl VmContext {
         sender: &Sender<OutputEvent>,
     ) -> Result<()> {
         let kvm_run = bsp.get_kvm_run_block()?;
+        let kvm_run = kvm_run.as_ptr();
 
         while !done.load(Ordering::Relaxed) {
             let exit = kvm_run.read().exit();


### PR DESCRIPTION
It turns out if we don't unmap this, the VM won't get properly shut down and we eventually run out of HKIDs.