### PR TITLE
remove gcc.tar.gz

### DIFF
--- a/tee/Cargo.lock
+++ b/tee/Cargo.lock
@@ -64,7 +64,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.92",
 ]
 
 [[package]]
@@ -121,7 +121,7 @@ source = "git+https://github.com/Freax13/bytemuck.git?rev=be10405#be10405b1de5db
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.92",
 ]
 
 [[package]]
@@ -243,6 +243,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "flate2",
+ "include_optional",
  "nix",
  "tar",
 ]
@@ -313,7 +314,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.92",
 ]
 
 [[package]]
@@ -391,6 +392,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "include_optional"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3328afceb205b7534c691f71b12334973dbfdfe0eecb9e345bddfbb925bc55fc"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,7 +450,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.92",
 ]
 
 [[package]]
@@ -476,7 +487,7 @@ checksum = "edbe595006d355eaf9ae11db92707d4338cd2384d16866131cc1afdbdd35d8d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.92",
 ]
 
 [[package]]
@@ -555,7 +566,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.92",
 ]
 
 [[package]]
@@ -748,6 +759,17 @@ dependencies = [
  "tdx-types",
  "volatile 0.6.1",
  "x86_64",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/tee/example/Cargo.toml
+++ b/tee/example/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.81"
 flate2 = "1.0.28"
+include_optional = "1.0.1"
 nix = { version = "0.29.0", default-features = false, features = ["mount"] }
 tar = "0.4.40"

--- a/tee/example/gcc.tar.gz
+++ b/tee/example/gcc.tar.gz
@@ -1,1 +1,0 @@
-This file is a placeholder.

--- a/tee/example/src/main.rs
+++ b/tee/example/src/main.rs
@@ -5,10 +5,11 @@ use std::{
 
 use anyhow::{Context, Result};
 use flate2::bufread::GzDecoder;
+use include_optional::include_bytes_optional;
 use nix::mount::{mount, MsFlags};
 use tar::Archive;
 
-const BYTES: &[u8] = include_bytes!("../gcc.tar.gz");
+const BYTES: Option<&[u8]> = include_bytes_optional!("../gcc.tar.gz");
 
 fn main() -> Result<()> {
     let root = "/";
@@ -23,7 +24,8 @@ fn main() -> Result<()> {
     .context("failed to mount /dev")?;
 
     // Unpack tar archive.
-    let file = Cursor::new(BYTES);
+    let bytes = BYTES.expect("gcc.tar.gz file was missing at compile time");
+    let file = Cursor::new(bytes);
     let buf_reader = BufReader::new(file);
     let reader = GzDecoder::new(buf_reader);
     let mut archive = Archive::new(reader);


### PR DESCRIPTION
Previously, the example crate failed to compile when this file was not present, so we had an empty file checked it. Instead, use include_bytes_optional! and remove the file.