### PR TITLE
shutdown less gracefully when linger is 0

### DIFF
--- a/tee/kernel/src/fs/fd/stream_buffer.rs
+++ b/tee/kernel/src/fs/fd/stream_buffer.rs
@@ -177,16 +177,16 @@ impl ReadHalf {
 
         // Check if there is data to receive.
         if guard.bytes.is_empty() {
+            // Check if the write half has been closed.
+            if guard.read_shutdown || guard.write_shutdown {
+                return Ok(0);
+            }
+
             if Arc::strong_count(&self.data) == 1 {
                 match guard.ty {
                     Type::Pipe { .. } => return Ok(0),
                     Type::Socket => bail!(ConnReset),
                 }
-            }
-
-            // Check if the write half has been closed.
-            if guard.read_shutdown || guard.write_shutdown {
-                return Ok(0);
             }
 
             bail!(Again);
@@ -235,16 +235,16 @@ impl ReadHalf {
 
         // Check if there is data to receive.
         if guard.bytes.is_empty() {
+            // Check if the write half has been closed.
+            if guard.read_shutdown || guard.write_shutdown {
+                return Ok(0);
+            }
+
             if Arc::strong_count(&self.data) == 1 {
                 match guard.ty {
                     Type::Pipe { .. } => return Ok(0),
                     Type::Socket => bail!(ConnReset),
                 }
-            }
-
-            // Check if the write half has been closed.
-            if guard.read_shutdown || guard.write_shutdown {
-                return Ok(0);
             }
 
             bail!(Again);
@@ -331,16 +331,16 @@ impl ReadHalf {
 
         // Bail out early if there are no bytes to be copied.
         if guard.bytes.is_empty() {
+            // Check if the write half has been closed.
+            if guard.read_shutdown || guard.write_shutdown {
+                return Ok(Ok(0));
+            }
+
             if Arc::strong_count(&self.data) == 1 {
                 match guard.ty {
                     Type::Pipe { .. } => return Ok(Ok(0)),
                     Type::Socket => bail!(ConnReset),
                 }
-            }
-
-            // Check if the write half has been closed.
-            if guard.read_shutdown || guard.write_shutdown {
-                return Ok(Ok(0));
             }
 
             return Ok(Err(PipeBlocked));

--- a/tee/kernel/src/fs/fd/unix_socket/stream.rs
+++ b/tee/kernel/src/fs/fd/unix_socket/stream.rs
@@ -236,3 +236,10 @@ impl OpenFileDescription for StreamUnixSocket {
         Ok(&self.file_lock)
     }
 }
+
+impl Drop for StreamUnixSocket {
+    fn drop(&mut self) {
+        self.read_half.shutdown();
+        self.write_half.shutdown();
+    }
+}

--- a/tee/kernel/src/net/tcp.rs
+++ b/tee/kernel/src/net/tcp.rs
@@ -951,6 +951,12 @@ impl Drop for TcpSocket {
         };
         let linger = self.internal.get_mut().linger.unwrap_or(60);
 
+        // When linger is 0, we skip the normal shutdown procedure and
+        // immediately disconnect the socket.
+        if linger == 0 {
+            return;
+        }
+
         let now = now(ClockId::Monotonic);
         let deadline = now.saturating_add(Timespec {
             tv_sec: linger as u32,


### PR DESCRIPTION
When linger is 0, the kernel is supposed to immediately reset the connection instead of doing the normal shutdown.