### PR TITLE
rewrite unix stream sockets

### DIFF
--- a/tee/kernel/src/fs/fd.rs
+++ b/tee/kernel/src/fs/fd.rs
@@ -24,7 +24,7 @@ use crate::{
         memory::VirtualMemory,
         syscall::{
             args::{
-                Accept4Flags, EpollEvent, FdNum, FileMode, FileType, OpenFlags, Pointer,
+                Accept4Flags, EpollEvent, FdNum, FileMode, FileType, MsgHdr, OpenFlags, Pointer,
                 RecvFromFlags, SentToFlags, ShutdownHow, SocketAddr, Stat, Timespec, Whence,
             },
             traits::Abi,
@@ -457,10 +457,12 @@ pub trait OpenFileDescription: Send + Sync + 'static {
         virtual_memory: &VirtualMemory,
         addr: Pointer<SocketAddr>,
         addrlen: usize,
+        ctx: &mut FileAccessContext,
     ) -> Result<()> {
         let _ = virtual_memory;
         let _ = addr;
         let _ = addrlen;
+        let _ = ctx;
         bail!(NotSock)
     }
 
@@ -479,6 +481,7 @@ pub trait OpenFileDescription: Send + Sync + 'static {
         virtual_memory: &VirtualMemory,
         addr: Pointer<SocketAddr>,
         addrlen: usize,
+        _: &mut FileAccessContext,
     ) -> Result<()> {
         let _ = virtual_memory;
         let _ = addr;
@@ -535,9 +538,39 @@ pub trait OpenFileDescription: Send + Sync + 'static {
         bail!(Inval)
     }
 
+    fn send_msg(
+        &self,
+        vm: &VirtualMemory,
+        abi: Abi,
+        msg_hdr: &mut MsgHdr,
+        fdtable: &FileDescriptorTable,
+    ) -> Result<usize> {
+        let _ = vm;
+        let _ = abi;
+        let _ = msg_hdr;
+        let _ = fdtable;
+        bail!(Inval)
+    }
+
     fn recv_from(&self, buf: &mut dyn ReadBuf, flags: RecvFromFlags) -> Result<usize> {
         let _ = buf;
         let _ = flags;
+        bail!(Inval)
+    }
+
+    fn recv_msg(
+        &self,
+        vm: &VirtualMemory,
+        abi: Abi,
+        msg_hdr: &mut MsgHdr,
+        fdtable: &FileDescriptorTable,
+        no_file_limit: CurrentNoFileLimit,
+    ) -> Result<usize> {
+        let _ = vm;
+        let _ = abi;
+        let _ = msg_hdr;
+        let _ = fdtable;
+        let _ = no_file_limit;
         bail!(Inval)
     }
 

--- a/tee/kernel/src/fs/fd/pipe/anon.rs
+++ b/tee/kernel/src/fs/fd/pipe/anon.rs
@@ -158,7 +158,7 @@ pub struct WriteHalf {
 #[async_trait::async_trait]
 impl OpenFileDescription for WriteHalf {
     fn flags(&self) -> OpenFlags {
-        *self.flags.lock()
+        *self.flags.lock() | OpenFlags::WRONLY
     }
 
     fn set_flags(&self, flags: OpenFlags) {

--- a/tee/kernel/src/fs/node/directory.rs
+++ b/tee/kernel/src/fs/node/directory.rs
@@ -2,6 +2,7 @@ use super::DirEntryName;
 use crate::{
     error::err,
     fs::{
+        fd::unix_socket::StreamUnixSocket,
         node::{DynINode, FileAccessContext, INode},
         path::{FileName, Path},
     },
@@ -87,6 +88,18 @@ macro_rules! dir_impls {
             gid: Gid,
         ) -> Result<()> {
             Directory::create_fifo(self, file_name, mode, uid, gid)
+        }
+
+        fn bind_socket(
+            &self,
+            file_name: FileName<'static>,
+            mode: FileMode,
+            uid: Uid,
+            gid: Gid,
+            socket: &crate::fs::fd::unix_socket::StreamUnixSocket,
+            socketname: &Path,
+        ) -> Result<()> {
+            Directory::bind_socket(self, file_name, mode, uid, gid, socket, socketname)
         }
 
         fn is_empty_dir(&self) -> bool {
@@ -184,6 +197,15 @@ pub trait Directory: INode {
         mode: FileMode,
         uid: Uid,
         gid: Gid,
+    ) -> Result<()>;
+    fn bind_socket(
+        &self,
+        file_name: FileName<'static>,
+        mode: FileMode,
+        uid: Uid,
+        gid: Gid,
+        socket: &StreamUnixSocket,
+        socketname: &Path,
     ) -> Result<()>;
     fn is_empty(&self) -> bool;
     fn list_entries(&self, ctx: &mut FileAccessContext) -> Result<Vec<DirEntry>>;

--- a/tee/kernel/src/fs/node/procfs.rs
+++ b/tee/kernel/src/fs/node/procfs.rs
@@ -18,6 +18,7 @@ use crate::{
             FileDescriptor, FileLockRecord, LazyFileLockRecord, ReadBuf, WriteBuf,
             dir::open_dir,
             file::{File, open_file},
+            unix_socket::StreamUnixSocket,
         },
         node::DirEntryName,
         path::{FileName, Path},
@@ -206,6 +207,18 @@ impl Directory for ProcFsRoot {
         _mode: FileMode,
         _uid: Uid,
         _gid: Gid,
+    ) -> Result<()> {
+        bail!(NoEnt)
+    }
+
+    fn bind_socket(
+        &self,
+        _file_name: FileName<'static>,
+        _mode: FileMode,
+        _uid: Uid,
+        _gid: Gid,
+        _: &StreamUnixSocket,
+        _socketname: &Path,
     ) -> Result<()> {
         bail!(NoEnt)
     }
@@ -548,6 +561,18 @@ impl Directory for ProcessDir {
         bail!(NoEnt)
     }
 
+    fn bind_socket(
+        &self,
+        _file_name: FileName<'static>,
+        _mode: FileMode,
+        _uid: Uid,
+        _gid: Gid,
+        _: &StreamUnixSocket,
+        _socketname: &Path,
+    ) -> Result<()> {
+        bail!(NoEnt)
+    }
+
     fn is_empty(&self) -> bool {
         false
     }
@@ -759,6 +784,18 @@ impl Directory for FdDir {
         _mode: FileMode,
         _uid: Uid,
         _gid: Gid,
+    ) -> Result<()> {
+        bail!(NoEnt)
+    }
+
+    fn bind_socket(
+        &self,
+        _file_name: FileName<'static>,
+        _mode: FileMode,
+        _uid: Uid,
+        _gid: Gid,
+        _: &StreamUnixSocket,
+        _socketname: &Path,
     ) -> Result<()> {
         bail!(NoEnt)
     }

--- a/tee/kernel/src/fs/path.rs
+++ b/tee/kernel/src/fs/path.rs
@@ -9,7 +9,7 @@ use crate::error::{Result, bail, ensure};
 
 pub const PATH_MAX: usize = 0x1000;
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Path {
     bytes: Arc<[u8]>,
 }

--- a/tee/kernel/src/main.rs
+++ b/tee/kernel/src/main.rs
@@ -21,7 +21,8 @@
     slice_ptr_get,
     step_trait,
     sync_unsafe_cell,
-    try_trait_v2
+    try_trait_v2,
+    vec_deque_pop_if
 )]
 #![forbid(unsafe_op_in_unsafe_fn)]
 #![allow(incomplete_features, internal_features)]

--- a/tee/kernel/src/net/tcp.rs
+++ b/tee/kernel/src/net/tcp.rs
@@ -325,6 +325,7 @@ impl OpenFileDescription for TcpSocket {
         virtual_memory: &VirtualMemory,
         addr: Pointer<SocketAddr>,
         addrlen: usize,
+        _: &mut FileAccessContext,
     ) -> Result<()> {
         ensure!(addrlen == size_of::<SocketAddr>(), Inval);
         let addr = virtual_memory.read(addr)?;
@@ -457,6 +458,7 @@ impl OpenFileDescription for TcpSocket {
         virtual_memory: &VirtualMemory,
         addr: Pointer<SocketAddr>,
         addrlen: usize,
+        _: &mut FileAccessContext,
     ) -> Result<()> {
         let bound = self.get_or_bind_ephemeral()?;
 

--- a/tee/kernel/src/user/process/syscall/args/pointee.rs
+++ b/tee/kernel/src/user/process/syscall/args/pointee.rs
@@ -811,6 +811,10 @@ pub struct Stat64 {
     pub _unused: [i64; 3],
 }
 
+impl Pointee for super::Stat64 {}
+
+impl PrimitivePointee for super::Stat64 {}
+
 impl TryFrom<Stat> for Stat32 {
     type Error = Error;
 

--- a/tee/tests/Cargo.toml
+++ b/tee/tests/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
-nix = { version = "0.29.0", features = ["mman", "net", "poll", "signal", "socket"] }
+nix = { version = "0.29.0", features = ["event", "fs", "mman", "net", "poll", "signal", "socket", "uio"] }

--- a/tee/tests/src/lib.rs
+++ b/tee/tests/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 mod net;
+mod unix;
 
 use std::{
     alloc::{Layout, alloc, dealloc},

--- a/tee/tests/src/unix.rs
+++ b/tee/tests/src/unix.rs
@@ -1,0 +1,503 @@
+use std::{
+    fs::File,
+    io::{IoSlice, IoSliceMut},
+    os::fd::{AsRawFd, IntoRawFd, RawFd},
+};
+
+use nix::{
+    cmsg_space,
+    errno::Errno,
+    fcntl::OFlag,
+    sys::{
+        eventfd::EventFd,
+        socket::{
+            AddressFamily, Backlog, ControlMessage, ControlMessageOwned, MsgFlags, Shutdown,
+            SockFlag, SockType, UnixAddr, bind, connect, getsockname, listen, recv, recvmsg, send,
+            sendmsg, shutdown, socket, socketpair,
+        },
+        stat::fstat,
+    },
+    unistd::{close, pipe, pipe2, read, unlink, write},
+};
+
+#[test]
+fn path_server_stat() {
+    let socket = socket(
+        AddressFamily::Unix,
+        SockType::Stream,
+        SockFlag::empty(),
+        None,
+    )
+    .unwrap();
+    let unbound_stat = fstat(socket.as_raw_fd()).unwrap();
+
+    let path = "socket-stat";
+    bind(socket.as_raw_fd(), &UnixAddr::new(path).unwrap()).unwrap();
+
+    let bound_stat = fstat(socket.as_raw_fd()).unwrap();
+
+    assert_eq!(unbound_stat, bound_stat);
+
+    unlink(path).unwrap();
+}
+
+#[test]
+fn path_double_bind() {
+    let sock = socket(
+        AddressFamily::Unix,
+        SockType::Stream,
+        SockFlag::empty(),
+        None,
+    )
+    .unwrap();
+    let unbound_stat = fstat(sock.as_raw_fd()).unwrap();
+
+    // Sockets start out as unnamed sockets.
+    let addr = getsockname::<UnixAddr>(sock.as_raw_fd()).unwrap();
+    assert!(addr.is_unnamed());
+
+    // Bind the socket to a path.
+    let path = "socket-double-bind";
+    bind(sock.as_raw_fd(), &UnixAddr::new(path).unwrap()).unwrap();
+
+    // The socketname should now reflect the path.
+    let addr = getsockname::<UnixAddr>(sock.as_raw_fd()).unwrap();
+    assert!(addr.path().is_some_and(|p| p.as_os_str() == path));
+
+    // Binding the same address should fail.
+    assert_eq!(
+        bind(sock.as_raw_fd(), &UnixAddr::new(path).unwrap()),
+        Err(Errno::EADDRINUSE)
+    );
+
+    // Binding again to another address should fail.
+    let path2 = "socket-double-bind2";
+    assert_eq!(
+        bind(sock.as_raw_fd(), &UnixAddr::new(path2).unwrap()),
+        Err(Errno::EINVAL)
+    );
+
+    // Create another socket.
+    let sock2 = socket(
+        AddressFamily::Unix,
+        SockType::Stream,
+        SockFlag::empty(),
+        None,
+    )
+    .unwrap();
+
+    // Binding the same address should fail.
+    assert_eq!(
+        bind(sock2.as_raw_fd(), &UnixAddr::new(path).unwrap()),
+        Err(Errno::EADDRINUSE)
+    );
+
+    // Close the socket.
+    drop(sock);
+
+    // Binding should still fail.
+    assert_eq!(
+        bind(sock2.as_raw_fd(), &UnixAddr::new(path).unwrap()),
+        Err(Errno::EADDRINUSE)
+    );
+
+    unlink(path).unwrap();
+}
+
+#[test]
+fn sendmsg_rights() {
+    let (sock1, sock2) = socketpair(
+        AddressFamily::Unix,
+        SockType::Stream,
+        None,
+        SockFlag::empty(),
+    )
+    .unwrap();
+
+    let efd1 = EventFd::new().unwrap();
+
+    assert_eq!(
+        sendmsg::<()>(
+            sock1.as_raw_fd(),
+            &[IoSlice::new(b"1234")],
+            &[ControlMessage::ScmRights(&[efd1.as_raw_fd()])],
+            MsgFlags::empty(),
+            None,
+        )
+        .unwrap(),
+        4
+    );
+
+    let mut cmsg_buffer = cmsg_space!([RawFd; 2]);
+    let mut buffer = [0; 4];
+    let mut slice_mut = IoSliceMut::new(&mut buffer);
+    let msg = recvmsg::<()>(
+        sock2.as_raw_fd(),
+        core::slice::from_mut(&mut slice_mut),
+        Some(&mut cmsg_buffer),
+        MsgFlags::empty(),
+    )
+    .unwrap();
+    assert_eq!(msg.bytes, 4);
+
+    let mut cmsgs_iter = msg.cmsgs().unwrap();
+    let cmsg = cmsgs_iter.next().unwrap();
+    let ControlMessageOwned::ScmRights(creds) = cmsg else {
+        unreachable!()
+    };
+    assert!(creds.len() == 1);
+    let efd2 = unsafe { std::mem::transmute::<_, EventFd>(creds[0]) };
+
+    efd1.write(5).unwrap();
+    assert_eq!(efd2.read().unwrap(), 5);
+
+    assert_eq!(buffer, *b"1234");
+}
+
+#[test]
+fn sendmsg_boundary() {
+    let (sock1, sock2) = socketpair(
+        AddressFamily::Unix,
+        SockType::Stream,
+        None,
+        SockFlag::empty(),
+    )
+    .unwrap();
+
+    let efd1 = EventFd::new().unwrap();
+
+    assert_eq!(
+        sendmsg::<()>(
+            sock1.as_raw_fd(),
+            &[IoSlice::new(b"1234")],
+            &[ControlMessage::ScmRights(&[efd1.as_raw_fd()])],
+            MsgFlags::empty(),
+            None,
+        )
+        .unwrap(),
+        4
+    );
+
+    assert_eq!(
+        send(sock1.as_raw_fd(), b"5678", MsgFlags::empty()).unwrap(),
+        4
+    );
+
+    assert_eq!(
+        sendmsg::<()>(
+            sock1.as_raw_fd(),
+            &[IoSlice::new(b"1234")],
+            &[ControlMessage::ScmRights(&[efd1.as_raw_fd()])],
+            MsgFlags::empty(),
+            None,
+        )
+        .unwrap(),
+        4
+    );
+
+    assert_eq!(
+        send(sock1.as_raw_fd(), b"5678", MsgFlags::empty()).unwrap(),
+        4
+    );
+
+    assert_eq!(
+        sendmsg::<()>(
+            sock1.as_raw_fd(),
+            &[IoSlice::new(b"1234")],
+            &[ControlMessage::ScmRights(&[efd1.as_raw_fd()])],
+            MsgFlags::empty(),
+            None,
+        )
+        .unwrap(),
+        4
+    );
+
+    assert_eq!(
+        send(sock1.as_raw_fd(), b"5678", MsgFlags::empty()).unwrap(),
+        4
+    );
+
+    let mut cmsg_buffer = cmsg_space!([RawFd; 1]);
+    let mut buffer = [0; 8];
+    let mut slice_mut = IoSliceMut::new(&mut buffer);
+    let msg = recvmsg::<()>(
+        sock2.as_raw_fd(),
+        core::slice::from_mut(&mut slice_mut),
+        Some(&mut cmsg_buffer),
+        MsgFlags::empty(),
+    )
+    .unwrap();
+    assert_eq!(msg.bytes, 4);
+
+    let mut cmsgs_iter = msg.cmsgs().unwrap();
+    let cmsg = cmsgs_iter.next().unwrap();
+    let ControlMessageOwned::ScmRights(creds) = cmsg else {
+        unreachable!()
+    };
+    assert!(creds.len() == 1);
+    let efd2 = unsafe { std::mem::transmute::<_, EventFd>(creds[0]) };
+
+    efd1.write(5).unwrap();
+    assert_eq!(efd2.read().unwrap(), 5);
+
+    assert_eq!(buffer[..4], *b"1234");
+
+    let mut cmsg_buffer = cmsg_space!([RawFd; 1]);
+    let mut buffer = [0; 16];
+    let mut slice_mut = IoSliceMut::new(&mut buffer);
+    let msg = recvmsg::<()>(
+        sock2.as_raw_fd(),
+        core::slice::from_mut(&mut slice_mut),
+        Some(&mut cmsg_buffer),
+        MsgFlags::empty(),
+    )
+    .unwrap();
+    assert_eq!(msg.bytes, 8);
+
+    let mut cmsgs_iter = msg.cmsgs().unwrap();
+    let cmsg = cmsgs_iter.next().unwrap();
+    let ControlMessageOwned::ScmRights(creds) = cmsg else {
+        unreachable!()
+    };
+    assert!(creds.len() == 1);
+    let efd2 = unsafe { std::mem::transmute::<_, EventFd>(creds[0]) };
+
+    efd1.write(5).unwrap();
+    assert_eq!(efd2.read().unwrap(), 5);
+
+    assert_eq!(buffer[..8], *b"56781234");
+
+    let mut cmsg_buffer = cmsg_space!([RawFd; 1]);
+    let mut buffer = [0; 4];
+    let mut slice_mut = IoSliceMut::new(&mut buffer);
+    let msg = recvmsg::<()>(
+        sock2.as_raw_fd(),
+        core::slice::from_mut(&mut slice_mut),
+        Some(&mut cmsg_buffer),
+        MsgFlags::empty(),
+    )
+    .unwrap();
+    assert_eq!(msg.bytes, 4);
+    assert_eq!(buffer[..4], *b"5678");
+
+    let mut cmsg_buffer = cmsg_space!([RawFd; 1]);
+    let mut buffer = [0; 2];
+    let mut slice_mut = IoSliceMut::new(&mut buffer);
+    let msg = recvmsg::<()>(
+        sock2.as_raw_fd(),
+        core::slice::from_mut(&mut slice_mut),
+        Some(&mut cmsg_buffer),
+        MsgFlags::empty(),
+    )
+    .unwrap();
+    assert_eq!(msg.bytes, 2);
+
+    let mut cmsgs_iter = msg.cmsgs().unwrap();
+    let cmsg = cmsgs_iter.next().unwrap();
+    let ControlMessageOwned::ScmRights(creds) = cmsg else {
+        unreachable!()
+    };
+    assert!(creds.len() == 1);
+    let efd2 = unsafe { std::mem::transmute::<_, EventFd>(creds[0]) };
+
+    efd1.write(5).unwrap();
+    assert_eq!(efd2.read().unwrap(), 5);
+
+    assert_eq!(buffer[..2], *b"12");
+
+    let mut cmsg_buffer = cmsg_space!([RawFd; 1]);
+    let mut buffer = [0; 8];
+    let mut slice_mut = IoSliceMut::new(&mut buffer);
+    let msg = recvmsg::<()>(
+        sock2.as_raw_fd(),
+        core::slice::from_mut(&mut slice_mut),
+        Some(&mut cmsg_buffer),
+        MsgFlags::empty(),
+    )
+    .unwrap();
+    assert_eq!(msg.bytes, 6);
+
+    let mut cmsgs_iter = msg.cmsgs().unwrap();
+    assert!(cmsgs_iter.next().is_none());
+    assert_eq!(buffer[..6], *b"345678");
+}
+
+#[test]
+fn sendmsg_recv() {
+    let (sock1, sock2) = socketpair(
+        AddressFamily::Unix,
+        SockType::Stream,
+        None,
+        SockFlag::empty(),
+    )
+    .unwrap();
+
+    let (read_half, write_half) = pipe2(OFlag::O_NONBLOCK).unwrap();
+
+    // Make sure that reading the pipe blocks.
+    let mut buf = [0; 8];
+    assert_eq!(read(read_half.as_raw_fd(), &mut buf), Err(Errno::EAGAIN));
+
+    // Send the write half over the socket.
+    assert_eq!(
+        sendmsg::<()>(
+            sock1.as_raw_fd(),
+            &[IoSlice::new(b"1234")],
+            &[ControlMessage::ScmRights(&[write_half.as_raw_fd()])],
+            MsgFlags::empty(),
+            None,
+        )
+        .unwrap(),
+        4
+    );
+    drop(write_half);
+
+    // Make sure that reading the pipe still blocks.
+    assert_eq!(read(read_half.as_raw_fd(), &mut buf), Err(Errno::EAGAIN));
+
+    // Receive the data. This implicitely closes the fd.
+    assert_eq!(
+        recv(sock2.as_raw_fd(), &mut buf, MsgFlags::empty()).unwrap(),
+        4
+    );
+
+    // Make sure that the pipe is blocked.
+    assert_eq!(read(read_half.as_raw_fd(), &mut buf).unwrap(), 0);
+}
+
+#[test]
+fn sendmsg_empty() {
+    let (sock1, sock2) = socketpair(
+        AddressFamily::Unix,
+        SockType::Stream,
+        None,
+        SockFlag::empty(),
+    )
+    .unwrap();
+
+    let efd1 = EventFd::new().unwrap();
+
+    // Send the fd over the socket.
+    assert_eq!(
+        sendmsg::<()>(
+            sock1.as_raw_fd(),
+            &[IoSlice::new(b"")],
+            &[ControlMessage::ScmRights(&[efd1.as_raw_fd()])],
+            MsgFlags::empty(),
+            None,
+        )
+        .unwrap(),
+        0
+    );
+
+    // Send some more data.
+    send(sock1.as_raw_fd(), b"1234", MsgFlags::empty()).unwrap();
+
+    let mut cmsg_buffer = cmsg_space!([RawFd; 2]);
+    let mut buffer = [0; 8];
+    let mut slice_mut = IoSliceMut::new(&mut buffer);
+    let msg = recvmsg::<()>(
+        sock2.as_raw_fd(),
+        core::slice::from_mut(&mut slice_mut),
+        Some(&mut cmsg_buffer),
+        MsgFlags::empty(),
+    )
+    .unwrap();
+    assert_eq!(msg.bytes, 4);
+
+    let mut cmsgs_iter = msg.cmsgs().unwrap();
+    assert!(cmsgs_iter.next().is_none());
+
+    assert_eq!(buffer[..4], *b"1234");
+}
+
+#[test]
+fn shutdown_read_write() {
+    let (sock1, sock2) = socketpair(
+        AddressFamily::Unix,
+        SockType::Stream,
+        None,
+        SockFlag::empty(),
+    )
+    .unwrap();
+
+    let mut buffer = &mut [0; 4];
+
+    assert_eq!(write(&sock1, b"1111"), Ok(4));
+    assert_eq!(read(sock2.as_raw_fd(), buffer), Ok(4));
+    assert_eq!(buffer, b"1111");
+
+    assert_eq!(write(&sock2, b"2222"), Ok(4));
+    assert_eq!(read(sock1.as_raw_fd(), buffer), Ok(4));
+    assert_eq!(buffer, b"2222");
+
+    shutdown(sock1.as_raw_fd(), Shutdown::Write).unwrap();
+
+    assert_eq!(write(&sock1, b"3333"), Err(Errno::EPIPE));
+    assert_eq!(read(sock2.as_raw_fd(), buffer), Ok(0));
+
+    assert_eq!(write(&sock2, b"4444"), Ok(4));
+    assert_eq!(read(sock1.as_raw_fd(), buffer), Ok(4));
+    assert_eq!(buffer, b"4444");
+
+    assert_eq!(write(&sock2, b"5555"), Ok(4));
+
+    shutdown(sock1.as_raw_fd(), Shutdown::Read).unwrap();
+
+    assert_eq!(write(&sock2, b"6666"), Err(Errno::EPIPE));
+    assert_eq!(read(sock1.as_raw_fd(), buffer), Ok(4));
+    assert_eq!(buffer, b"5555");
+    assert_eq!(read(sock1.as_raw_fd(), buffer), Ok(0));
+    assert_eq!(buffer, b"5555");
+}
+
+#[test]
+fn connect_to_file() {
+    let client = socket(
+        AddressFamily::Unix,
+        SockType::Stream,
+        SockFlag::empty(),
+        None,
+    )
+    .unwrap();
+
+    // Connecting to a regular, non-socket file fails.
+    let path = "regular-file";
+    let file = File::create(path).unwrap();
+    let addr = UnixAddr::new(path).unwrap();
+    assert_eq!(connect(client.as_raw_fd(), &addr), Err(Errno::ECONNREFUSED));
+    unlink(path).unwrap();
+
+    let server = socket(
+        AddressFamily::Unix,
+        SockType::Stream,
+        SockFlag::empty(),
+        None,
+    )
+    .unwrap();
+    let path = "socket-connect";
+    let addr = UnixAddr::new(path).unwrap();
+    bind(server.as_raw_fd(), &addr).unwrap();
+
+    // Connecting to a socket that's not yet listening should fail.
+    assert_eq!(connect(client.as_raw_fd(), &addr), Err(Errno::ECONNREFUSED));
+
+    listen(&server, Backlog::MAXALLOWABLE).unwrap();
+
+    // Connecting to a listening socket should succeed.
+    assert_eq!(connect(client.as_raw_fd(), &addr), Ok(()));
+
+    let client = socket(
+        AddressFamily::Unix,
+        SockType::Stream,
+        SockFlag::empty(),
+        None,
+    )
+    .unwrap();
+
+    // Connecting to a closed socket should fail.
+    drop(server);
+    assert_eq!(connect(client.as_raw_fd(), &addr), Err(Errno::ECONNREFUSED));
+
+    unlink(path).unwrap();
+}


### PR DESCRIPTION
The new implementation has support for ancillary data. I decided not to add support for ancillary data to stream_buffer because stream_buffer is already fairly complicated and the effort to implement the data buffers has been greatly reduced since the user/kernel I/O consolidation.