### PR TITLE
implement id block signing

### DIFF
--- a/common/Cargo.lock
+++ b/common/Cargo.lock
@@ -174,6 +174,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "hkdf",
  "pem-rfc7468",
  "pkcs8",
  "rand_core",
@@ -243,6 +244,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +315,18 @@ name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -494,6 +516,7 @@ dependencies = [
  "bit_field",
  "bitflags",
  "bytemuck",
+ "p384",
  "paste",
  "serde",
  "x86_64",

--- a/common/snp-types/Cargo.toml
+++ b/common/snp-types/Cargo.toml
@@ -3,12 +3,11 @@ name = "snp-types"
 version = "0.1.0"
 edition.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-bitflags = { version = "2.4.2", features = ["bytemuck"] }
 bit_field = "0.10.2"
+bitflags = { version = "2.4.2", features = ["bytemuck"] }
 bytemuck = { version = "1.15.0", features = ["derive", "min_const_generics"] }
+p384 = { version = "0.13.1", optional = true }
 paste = "1.0.14"
 serde = { version = "1.0.210", features = ["derive"], optional = true }
 x86_64 = { version = "0.15.1", default-features = false }

--- a/common/snp-types/src/guest_policy.rs
+++ b/common/snp-types/src/guest_policy.rs
@@ -1,7 +1,7 @@
 use bit_field::BitField;
-use bytemuck::CheckedBitPattern;
+use bytemuck::{CheckedBitPattern, NoUninit};
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, NoUninit)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize),

--- a/common/snp-types/src/id_block.rs
+++ b/common/snp-types/src/id_block.rs
@@ -1,0 +1,126 @@
+use core::fmt;
+
+use bytemuck::{AnyBitPattern, CheckedBitPattern, NoUninit};
+#[cfg(feature = "p384")]
+use p384::ecdsa::VerifyingKey;
+
+use crate::guest_policy::GuestPolicy;
+
+pub use crate::attestation::EcdsaP384Sha384Signature;
+
+#[derive(Debug, Clone, Copy, CheckedBitPattern, NoUninit)]
+#[repr(C)]
+pub struct IdBlock {
+    pub launch_digest: [u8; 48],
+    pub family_id: [u8; 16],
+    pub image_id: [u8; 16],
+    pub version: u32,
+    pub guest_svn: u32,
+    pub policy: GuestPolicy,
+}
+
+#[derive(Debug, Clone, Copy, CheckedBitPattern, NoUninit)]
+#[repr(C)]
+pub struct IdAuthInfo {
+    pub id_key_algo: KeyAlgo,
+    pub auth_key_algo: KeyAlgo,
+    _reserved1: [u8; 0x40 - 0x8],
+    pub id_block_sig: EcdsaP384Sha384Signature,
+    pub id_key: PublicKey,
+    _reserved2: [u8; 0x680 - 0x644],
+    pub id_key_sig: EcdsaP384Sha384Signature,
+    pub author_key: PublicKey,
+    _reserved: [u8; 0x1000 - 0xc84],
+}
+
+impl IdAuthInfo {
+    pub fn new(
+        id_key_algo: KeyAlgo,
+        auth_key_algo: KeyAlgo,
+        id_block_sig: EcdsaP384Sha384Signature,
+        id_key: PublicKey,
+        id_key_sig: EcdsaP384Sha384Signature,
+        author_key: PublicKey,
+    ) -> Self {
+        Self {
+            id_key_algo,
+            auth_key_algo,
+            _reserved1: [0; 0x40 - 0x8],
+            id_block_sig,
+            id_key,
+            _reserved2: [0; 0x680 - 0x644],
+            id_key_sig,
+            author_key,
+            _reserved: [0; 0x1000 - 0xc84],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, CheckedBitPattern, NoUninit, PartialEq, Eq)]
+#[repr(u32)]
+pub enum KeyAlgo {
+    EcdsaP384Sha384 = 1,
+}
+
+#[derive(Debug, Clone, Copy, CheckedBitPattern, NoUninit)]
+#[repr(C, u32)]
+pub enum PublicKey {
+    P384(EcdsaP384PublicKey) = 2,
+}
+
+impl Default for PublicKey {
+    fn default() -> Self {
+        Self::P384(EcdsaP384PublicKey::default())
+    }
+}
+
+#[derive(Clone, Copy, AnyBitPattern, NoUninit)]
+#[repr(C)]
+pub struct EcdsaP384PublicKey {
+    pub qx: [u8; 72],
+    pub qy: [u8; 72],
+    _padding: [u8; 0x404 - 0x94],
+}
+
+impl EcdsaP384PublicKey {
+    pub fn new(qx: [u8; 72], qy: [u8; 72]) -> Self {
+        Self {
+            qx,
+            qy,
+            _padding: [0; 0x404 - 0x94],
+        }
+    }
+}
+
+impl fmt::Debug for EcdsaP384PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EcdsaP384PublicKey")
+            .field("r", &self.qx)
+            .field("s", &self.qy)
+            .finish()
+    }
+}
+
+#[cfg(feature = "p384")]
+impl From<VerifyingKey> for EcdsaP384PublicKey {
+    fn from(value: VerifyingKey) -> Self {
+        let point = value.to_encoded_point(false);
+        let x = *point.x().unwrap();
+        let y = *point.y().unwrap();
+        let mut x = <[u8; 48]>::from(x);
+        let mut y = <[u8; 48]>::from(y);
+        x.reverse();
+        y.reverse();
+        let mut qx = [0; 72];
+        let mut qy = [0; 72];
+        qx[0..48].copy_from_slice(&x);
+        qy[0..48].copy_from_slice(&y);
+        Self::new(qx, qy)
+    }
+}
+
+impl Default for EcdsaP384PublicKey {
+    fn default() -> Self {
+        Self::new([0; 72], [0; 72])
+    }
+}

--- a/common/snp-types/src/lib.rs
+++ b/common/snp-types/src/lib.rs
@@ -10,6 +10,7 @@ pub mod cpuid;
 pub mod ghcb;
 pub mod guest_message;
 pub mod guest_policy;
+pub mod id_block;
 pub mod intercept;
 pub mod secrets;
 pub mod vmsa;

--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -919,6 +919,7 @@ name = "mushroom-verify"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
+ "ecdsa",
  "io",
  "loader",
  "p384",
@@ -1540,6 +1541,7 @@ dependencies = [
  "bit_field",
  "bitflags",
  "bytemuck",
+ "p384",
  "paste",
  "serde",
  "x86_64",

--- a/host/mushroom-verify/Cargo.toml
+++ b/host/mushroom-verify/Cargo.toml
@@ -5,12 +5,13 @@ edition.workspace = true
 
 [dependencies]
 bytemuck = { version = "1.15.0", features = ["derive", "min_const_generics"], optional = true }
+ecdsa = "0.16.9"
 io = { workspace = true }
 loader = { workspace = true }
 p384 = { version = "0.13.0", optional = true }
 serde = { version = "1.0.213", features = ["derive"], optional = true }
 sha2 = "0.10.8"
-snp-types = { workspace = true, optional = true }
+snp-types = { workspace = true, features = ["p384"], optional = true }
 tdx-types = { workspace = true, features = ["quote"], optional = true }
 thiserror = "2.0.9"
 vcek-kds = { workspace = true, optional = true }

--- a/host/mushroom-verify/src/lib.rs
+++ b/host/mushroom-verify/src/lib.rs
@@ -13,7 +13,10 @@ pub use tdx_types::td_quote::TeeTcbSvn;
 #[cfg(feature = "serde")]
 mod hex;
 #[cfg(feature = "snp")]
-mod snp;
+// mushroom uses some code in this module. But it shouldn't be considered part
+// of the public API.
+#[doc(hidden)]
+pub mod snp;
 #[cfg(feature = "tdx")]
 mod tdx;
 


### PR DESCRIPTION
ID block signatures are required for attestation security. They're not optional.
Starting with this commit, we require ID block and ID block signatures. The public key is derived using public key recovery and a fixed signature. This scheme allows us to have a signing key without a trusted party that holds the private key.