### PR TITLE
don't fail brk if new address isn't valid

### DIFF
--- a/tee/kernel/src/user/process/syscall.rs
+++ b/tee/kernel/src/user/process/syscall.rs
@@ -717,9 +717,9 @@ fn brk(#[state] virtual_memory: Arc<VirtualMemory>, brk_value: u64) -> SyscallRe
     ensure!(brk_value % 0x1000 == 0, Inval);
 
     if brk_value != 0 {
-        let _ = virtual_memory
-            .modify()
-            .set_brk_end(VirtAddr::new(brk_value));
+        if let Ok(brk_value) = VirtAddr::try_new(brk_value) {
+            let _ = virtual_memory.modify().set_brk_end(brk_value);
+        }
     }
 
     Ok(virtual_memory.brk_end().as_u64())


### PR DESCRIPTION
If the new address isn't valid, we should just return the old address.