### PR TITLE
implement sparse buffers 

### DIFF
--- a/tee/kernel/src/char_dev/mem.rs
+++ b/tee/kernel/src/char_dev/mem.rs
@@ -224,12 +224,12 @@ impl OpenFileDescription for Zero {
     }
 
     fn read(&self, buf: &mut dyn ReadBuf) -> Result<usize> {
-        buf.fill(0)?;
+        buf.fill_all(0)?;
         Ok(buf.buffer_len())
     }
 
     fn pread(&self, _pos: usize, buf: &mut dyn ReadBuf) -> Result<usize> {
-        buf.fill(0)?;
+        buf.fill_all(0)?;
         Ok(buf.buffer_len())
     }
 
@@ -354,12 +354,12 @@ impl OpenFileDescription for Full {
     }
 
     fn read(&self, buf: &mut dyn ReadBuf) -> Result<usize> {
-        buf.fill(0)?;
+        buf.fill_all(0)?;
         Ok(buf.buffer_len())
     }
 
     fn pread(&self, _pos: usize, buf: &mut dyn ReadBuf) -> Result<usize> {
-        buf.fill(0)?;
+        buf.fill_all(0)?;
         Ok(buf.buffer_len())
     }
 

--- a/tee/kernel/src/fs/fd/buf.rs
+++ b/tee/kernel/src/fs/fd/buf.rs
@@ -19,7 +19,9 @@ pub trait ReadBuf {
     fn buffer_len(&self) -> usize;
     fn write(&mut self, offset: usize, bytes: &[u8]) -> Result<()>;
     unsafe fn write_volatile(&mut self, offset: usize, bytes: NonNull<[u8]>) -> Result<()>;
-    fn fill(&mut self, byte: u8) -> Result<()>;
+    #[expect(dead_code)]
+    fn fill(&mut self, offset: usize, len: usize, byte: u8) -> Result<()>;
+    fn fill_all(&mut self, byte: u8) -> Result<()>;
 }
 
 pub trait WriteBuf {
@@ -58,7 +60,12 @@ impl ReadBuf for KernelReadBuf<'_> {
         Ok(())
     }
 
-    fn fill(&mut self, byte: u8) -> Result<()> {
+    fn fill(&mut self, offset: usize, len: usize, byte: u8) -> Result<()> {
+        self.0[offset..][..len].fill(byte);
+        Ok(())
+    }
+
+    fn fill_all(&mut self, byte: u8) -> Result<()> {
         self.0.fill(byte);
         Ok(())
     }
@@ -124,7 +131,14 @@ impl ReadBuf for UserBuf<'_> {
         unsafe { self.vm.write_bytes_volatile(addr, bytes) }
     }
 
-    fn fill(&mut self, byte: u8) -> Result<()> {
+    fn fill(&mut self, offset: usize, len: usize, byte: u8) -> Result<()> {
+        assert!(self.len >= offset + len);
+        self.vm
+            .set_bytes(self.pointer.bytes_offset(offset).get(), len, byte)?;
+        Ok(())
+    }
+
+    fn fill_all(&mut self, byte: u8) -> Result<()> {
         self.vm.set_bytes(self.pointer.get(), self.len, byte)?;
         Ok(())
     }
@@ -233,7 +247,30 @@ impl ReadBuf for VectoredUserBuf<'_> {
         unreachable!("wrote too many bytes to buffer")
     }
 
-    fn fill(&mut self, byte: u8) -> Result<()> {
+    fn fill(&mut self, mut offset: usize, mut len: usize, byte: u8) -> Result<()> {
+        for iv in self.iovec.iter_mut() {
+            let iv_len = usize_from(iv.len);
+            if let Some(chunk_len) = iv_len.checked_sub(offset).filter(|&len| len > 0) {
+                let chunk_len = cmp::max(chunk_len, len);
+                self.vm.set_bytes(
+                    VirtAddr::new(iv.base + u64::from_usize(offset)),
+                    chunk_len,
+                    byte,
+                )?;
+                offset = 0;
+                len -= chunk_len;
+                if len == 0 {
+                    break;
+                }
+            } else {
+                offset -= iv_len;
+            }
+        }
+        assert_eq!(len, 0);
+        Ok(())
+    }
+
+    fn fill_all(&mut self, byte: u8) -> Result<()> {
         for iv in self.iovec.iter_mut() {
             self.vm
                 .set_bytes(VirtAddr::new(iv.base), usize_from(iv.len), byte)?;

--- a/tee/kernel/src/fs/fd/buf.rs
+++ b/tee/kernel/src/fs/fd/buf.rs
@@ -19,7 +19,6 @@ pub trait ReadBuf {
     fn buffer_len(&self) -> usize;
     fn write(&mut self, offset: usize, bytes: &[u8]) -> Result<()>;
     unsafe fn write_volatile(&mut self, offset: usize, bytes: NonNull<[u8]>) -> Result<()>;
-    #[expect(dead_code)]
     fn fill(&mut self, offset: usize, len: usize, byte: u8) -> Result<()>;
     fn fill_all(&mut self, byte: u8) -> Result<()>;
 }

--- a/tee/kernel/src/memory/page/buffer.rs
+++ b/tee/kernel/src/memory/page/buffer.rs
@@ -1,190 +1,93 @@
-use core::{cmp, iter::repeat_with};
-
-use alloc::vec::Vec;
+use dense::{DenseBuffer, NotDenseError};
+use sparse::SparseBuffer;
 
 use crate::{
-    error::{Result, ensure},
+    error::Result,
     fs::fd::{ReadBuf, WriteBuf},
 };
 
 use super::KernelPage;
 
+mod dense;
+mod sparse;
+
 pub struct Buffer {
-    /// The length of the vector in bytes.
-    len: usize,
-    pages: Vec<KernelPage>,
+    buffer_impl: BufferImpl,
+}
+
+/// Sparse buffers may have holes, dense buffers may not. Dense buffers are
+/// generally faster.
+enum BufferImpl {
+    Dense(DenseBuffer),
+    Sparse(SparseBuffer),
 }
 
 impl Buffer {
     #[inline]
     pub fn new() -> Self {
         Self {
-            len: 0,
-            pages: Vec::new(),
+            buffer_impl: BufferImpl::Dense(DenseBuffer::new()),
         }
     }
 
     #[inline]
     pub fn len(&self) -> usize {
-        self.len
-    }
-
-    pub fn reserve(&mut self, additional: usize) -> Result<()> {
-        if additional == 0 {
-            return Ok(());
+        match &self.buffer_impl {
+            BufferImpl::Dense(buffer) => buffer.len(),
+            BufferImpl::Sparse(buffer) => buffer.len(),
         }
-
-        let total_len = self.len() + additional;
-        let num_pages = total_len.div_ceil(0x1000);
-        let new_pages = num_pages.saturating_sub(self.pages.len());
-
-        self.pages.try_reserve(new_pages)?;
-        self.pages
-            .extend(repeat_with(KernelPage::zeroed).take(new_pages));
-
-        Ok(())
-    }
-
-    /// Reserve `additional` bytes and make sure that they're all zero.
-    fn reserve_zeroed(&mut self, additional: usize) -> Result<()> {
-        if additional == 0 {
-            return Ok(());
-        }
-
-        if self.len() % 0x1000 != 0 {
-            let start = self.len() % 0x1000;
-            let idx = self.len() / 0x1000;
-            let page = &mut self.pages[idx];
-            page.zero_range(start.., true)?;
-        }
-
-        let following_pages = self.len().div_ceil(4096);
-        self.pages.drain(following_pages..);
-
-        self.reserve(additional)?;
-
-        Ok(())
     }
 
     pub fn read(&self, offset: usize, buf: &mut (impl ReadBuf + ?Sized)) -> Result<usize> {
-        let len = cmp::min(self.len.saturating_sub(offset), buf.buffer_len());
-        if len == 0 {
-            return Ok(0);
+        match &self.buffer_impl {
+            BufferImpl::Dense(buffer) => buffer.read(offset, buf),
+            BufferImpl::Sparse(buffer) => buffer.read(offset, buf),
         }
+    }
 
-        let start = offset;
-        let end = offset + len - 1;
+    fn do_buffer_op<R>(
+        &mut self,
+        mut dense: impl FnMut(&mut DenseBuffer) -> Result<Result<R, NotDenseError>>,
+        mut sparse: impl FnMut(&mut SparseBuffer) -> Result<R>,
+    ) -> Result<R> {
+        if let BufferImpl::Dense(buffer) = &mut self.buffer_impl {
+            // Attempt the operation on a dense buffer.
+            let res = dense(buffer)?;
 
-        let start_page = start / 0x1000;
-        let end_page = (end + 1).div_ceil(0x1000);
-
-        for (i, page) in self
-            .pages
-            .iter()
-            .enumerate()
-            .take(end_page)
-            .skip(start_page)
-        {
-            // Calcuate the start and end indices of `page` in `self`.
-            let page_start = i * 0x1000;
-            let page_end = (i + 1) * 0x1000 - 1;
-
-            // Calculate the start and end indices in `self` for the copy operation.
-            let copy_start = cmp::max(page_start, start);
-            let copy_end = cmp::min(page_end, end);
-
-            // Calculate the start and end indices in `page` for the copy operation.
-            let page_copy_start = copy_start - page_start;
-            let page_copy_end = copy_end - page_start;
-            let src = page.index(page_copy_start..=page_copy_end);
-
-            let buf_copy_start = copy_start - offset;
-            unsafe {
-                buf.write_volatile(buf_copy_start, src)?;
+            // If it succeeds, then return its result.
+            if let Ok(result) = res {
+                return Ok(result);
             }
+
+            // Otherwise convert the buffer into a sparse buffer and try again.
+            let buffer = core::mem::replace(buffer, DenseBuffer::new());
+            self.buffer_impl = BufferImpl::Sparse(SparseBuffer::from(buffer));
         }
 
-        Ok(len)
+        let BufferImpl::Sparse(buffer) = &mut self.buffer_impl else {
+            unreachable!()
+        };
+        sparse(buffer)
     }
 
     pub fn write(&mut self, offset: usize, buf: &dyn WriteBuf) -> Result<usize> {
-        // Zero reserve the memory between `len` and `offset`.
-        let needed_capacity = offset.saturating_sub(self.len());
-        self.reserve_zeroed(needed_capacity)?;
-
-        let len = buf.buffer_len();
-        if len == 0 {
-            return Ok(0);
-        }
-
-        // Reserve enough memory for the write.
-        let needed_capacity = (offset + len).saturating_sub(self.len());
-        self.reserve(needed_capacity)?;
-
-        let start = offset;
-        let end = offset + len - 1;
-
-        let start_page = start / 0x1000;
-        let end_page = (end + 1).div_ceil(0x1000);
-
-        for (i, page) in self
-            .pages
-            .iter_mut()
-            .enumerate()
-            .take(end_page)
-            .skip(start_page)
-        {
-            // Calcuate the start and end indices of `page` in `self`.
-            let page_start = i * 0x1000;
-            let page_end = (i + 1) * 0x1000 - 1;
-
-            // Calculate the start and end indices in `self` for the copy operation.
-            let copy_start = cmp::max(page_start, start);
-            let copy_end = cmp::min(page_end, end);
-
-            // Calculate the start and end indices in `page` for the copy operation.
-            let page_copy_start = copy_start - page_start;
-            let page_copy_end = copy_end - page_start;
-            page.make_mut(true)?;
-            let dst = page.index(page_copy_start..=page_copy_end);
-
-            let buf_copy_start = copy_start - offset;
-            unsafe {
-                buf.read_volatile(buf_copy_start, dst)?;
-            }
-        }
-
-        // Update the length.
-        self.len = cmp::max(self.len, offset + len);
-
-        Ok(len)
+        self.do_buffer_op(
+            |buffer| buffer.write(offset, buf),
+            |buffer| buffer.write(offset, buf),
+        )
     }
 
     pub fn truncate(&mut self, len: usize) -> Result<()> {
-        let additional = len.saturating_sub(self.len());
-        self.reserve_zeroed(additional)?;
-
-        self.len = len;
-
-        Ok(())
+        match &mut self.buffer_impl {
+            BufferImpl::Dense(buffer) => buffer.truncate(len),
+            BufferImpl::Sparse(buffer) => buffer.truncate(len),
+        }
     }
 
     pub fn get_page(&mut self, page_idx: usize, shared: bool) -> Result<KernelPage> {
-        ensure!(page_idx < self.pages.len(), Acces);
-
-        // Zero reserve until the end of the page to make sure that we don't
-        // leak unitialized bytes.
-        let end = (page_idx + 1) * 0x1000;
-        let additional = end.saturating_sub(self.len());
-        self.reserve_zeroed(additional)?;
-
-        // Always make shared pages mutable immediately. We need to do this
-        // because we need to ensure that calling `make_mut(...)` on the
-        // returned pages doesn't allocate a new page every time.
-        if shared {
-            self.pages[page_idx].make_mut(true)?;
-        }
-
-        self.pages[page_idx].clone()
+        self.do_buffer_op(
+            |buffer| buffer.get_page(page_idx, shared),
+            |buffer| buffer.get_page(page_idx, shared),
+        )
     }
 }

--- a/tee/kernel/src/memory/page/buffer/dense.rs
+++ b/tee/kernel/src/memory/page/buffer/dense.rs
@@ -1,0 +1,198 @@
+use core::{cmp, iter::repeat};
+
+use alloc::vec::Vec;
+
+use crate::{
+    error::{Result, ensure},
+    fs::fd::{ReadBuf, WriteBuf},
+};
+
+use super::{KernelPage, sparse::SparseBuffer};
+
+pub struct DenseBuffer {
+    /// The length of the buffer in bytes.
+    len: usize,
+    pages: Vec<KernelPage>,
+}
+
+impl DenseBuffer {
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            len: 0,
+            pages: Vec::new(),
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn read(&self, offset: usize, buf: &mut (impl ReadBuf + ?Sized)) -> Result<usize> {
+        let len = cmp::min(self.len.saturating_sub(offset), buf.buffer_len());
+        if len == 0 {
+            return Ok(0);
+        }
+
+        let start = offset;
+        let end = offset + len - 1;
+
+        let start_page = start / 0x1000;
+        let end_page = (end + 1).div_ceil(0x1000);
+
+        for (i, page) in self
+            .pages
+            .iter()
+            .chain(repeat(&KernelPage::zeroed())) // TODO: Zero the buffer directly instead of copying from the zero page.
+            .enumerate()
+            .take(end_page)
+            .skip(start_page)
+        {
+            // Calcuate the start and end indices of `page` in `self`.
+            let page_start = i * 0x1000;
+            let page_end = (i + 1) * 0x1000 - 1;
+
+            // Calculate the start and end indices in `self` for the copy operation.
+            let copy_start = cmp::max(page_start, start);
+            let copy_end = cmp::min(page_end, end);
+
+            // Calculate the start and end indices in `page` for the copy operation.
+            let page_copy_start = copy_start - page_start;
+            let page_copy_end = copy_end - page_start;
+            let src = page.index(page_copy_start..=page_copy_end);
+
+            let buf_copy_start = copy_start - offset;
+            unsafe {
+                buf.write_volatile(buf_copy_start, src)?;
+            }
+        }
+
+        Ok(len)
+    }
+
+    pub fn write(
+        &mut self,
+        offset: usize,
+        buf: &dyn WriteBuf,
+    ) -> Result<Result<usize, NotDenseError>> {
+        // Make sure that we don't need to add too many empty extra pages. If
+        // that's the case, the buffer likely isn't dense.
+        let start = offset;
+        let start_page = start / 0x1000;
+        let additional_pages = start_page.saturating_sub(self.pages.len());
+        if additional_pages > 128 {
+            return Ok(Err(NotDenseError));
+        }
+
+        // Add as many pages as required to pad to `offset`.
+        if self.pages.len() < start_page {
+            self.pages.resize_with(start_page, KernelPage::zeroed);
+        }
+
+        let len = buf.buffer_len();
+        if len == 0 {
+            return Ok(Ok(0));
+        }
+
+        // Add as many pages as required for the write.
+        let end = offset + len - 1;
+        let end_page = (end + 1).div_ceil(0x1000);
+        if self.pages.len() < end_page {
+            self.pages.resize_with(end_page, KernelPage::zeroed);
+        }
+
+        for (i, page) in self
+            .pages
+            .iter_mut()
+            .enumerate()
+            .take(end_page)
+            .skip(start_page)
+        {
+            // Calcuate the start and end indices of `page` in `self`.
+            let page_start = i * 0x1000;
+            let page_end = (i + 1) * 0x1000 - 1;
+
+            // Calculate the start and end indices in `self` for the copy operation.
+            let copy_start = cmp::max(page_start, start);
+            let copy_end = cmp::min(page_end, end);
+
+            // Calculate the start and end indices in `page` for the copy operation.
+            let page_copy_start = copy_start - page_start;
+            let page_copy_end = copy_end - page_start;
+            page.make_mut(true)?;
+            let dst = page.index(page_copy_start..=page_copy_end);
+
+            let buf_copy_start = copy_start - offset;
+            unsafe {
+                buf.read_volatile(buf_copy_start, dst)?;
+            }
+        }
+
+        // Update the length.
+        self.len = cmp::max(self.len, offset + len);
+
+        Ok(Ok(len))
+    }
+
+    pub fn truncate(&mut self, len: usize) -> Result<()> {
+        if len < self.len {
+            // Remove all completly truncated pages.
+            let remove_page_index = len.div_ceil(0x1000);
+            self.pages.truncate(remove_page_index);
+
+            // If the last page isn't fully truncated, just zero everything
+            // after `len`.
+            let page_offset = len % 0x1000;
+            let page_index = len / 0x1000;
+            if page_offset != 0 {
+                if let Some(page) = self.pages.get_mut(page_index) {
+                    page.zero_range(page_offset.., true)?;
+                }
+            }
+        }
+
+        self.len = len;
+
+        Ok(())
+    }
+
+    pub fn get_page(
+        &mut self,
+        page_idx: usize,
+        shared: bool,
+    ) -> Result<Result<KernelPage, NotDenseError>> {
+        ensure!(page_idx < self.pages.len(), Acces);
+
+        // Get the page. If it hasn't been allocated yet, it hasn't been
+        // written to yet and accesses are likely not dense.
+        let Some(page) = self.pages.get_mut(page_idx) else {
+            // If the page doesn't need to be shared, we can just return the
+            // zero page.
+            if !shared {
+                return Ok(Ok(KernelPage::zeroed()));
+            }
+
+            // Adding the page to the buffer would require making it sparse.
+            return Ok(Err(NotDenseError));
+        };
+
+        // Always make shared pages mutable immediately. We need to do this
+        // because we need to ensure that calling `make_mut(...)` on the
+        // returned pages doesn't allocate a new page every time.
+        if shared {
+            page.make_mut(true)?;
+        }
+
+        page.clone().map(Ok)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct NotDenseError;
+
+impl From<DenseBuffer> for SparseBuffer {
+    fn from(value: DenseBuffer) -> Self {
+        Self::new(value.len, value.pages.into_iter().enumerate())
+    }
+}

--- a/tee/kernel/src/memory/page/buffer/sparse.rs
+++ b/tee/kernel/src/memory/page/buffer/sparse.rs
@@ -1,0 +1,168 @@
+use core::{cmp, ops::Bound};
+
+use alloc::collections::btree_map::BTreeMap;
+
+use crate::{
+    error::{Result, ensure},
+    fs::fd::{ReadBuf, WriteBuf},
+    memory::page::KernelPage,
+};
+
+pub struct SparseBuffer {
+    /// The length of the buffer in bytes.
+    len: usize,
+    pages: BTreeMap<usize, KernelPage>,
+}
+
+impl SparseBuffer {
+    pub fn new(len: usize, pages: impl Iterator<Item = (usize, KernelPage)>) -> Self {
+        Self {
+            len,
+            pages: pages
+                .inspect(|(i, _)| {
+                    debug_assert!(i * 0x1000 < len);
+                })
+                .collect(),
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn read(&self, offset: usize, buf: &mut (impl ReadBuf + ?Sized)) -> Result<usize> {
+        let len = cmp::min(self.len.saturating_sub(offset), buf.buffer_len());
+        if len == 0 {
+            return Ok(0);
+        }
+
+        let start = offset;
+        let end = offset + len - 1;
+
+        let start_page = start / 0x1000;
+        let end_page = (end + 1).div_ceil(0x1000);
+
+        let mut iter = self.pages.range(start_page..end_page).peekable();
+        for i in start_page..end_page {
+            // Calcuate the start and end indices of `page` in `self`.
+            let page_start = i * 0x1000;
+            let page_end = (i + 1) * 0x1000 - 1;
+
+            // Calculate the start and end indices in `self` for the copy operation.
+            let copy_start = cmp::max(page_start, start);
+            let copy_end = cmp::min(page_end, end);
+
+            let buf_copy_start = copy_start - offset;
+
+            // If there's an i'th page, copy its content, otherwise just zero the memory.
+            if let Some((_, page)) = iter.next_if(|&(idx, _)| *idx == i) {
+                // Calculate the start and end indices in `page` for the copy operation.
+                let page_copy_start = copy_start - page_start;
+                let page_copy_end = copy_end - page_start;
+                let src = page.index(page_copy_start..=page_copy_end);
+
+                unsafe {
+                    buf.write_volatile(buf_copy_start, src)?;
+                }
+            } else {
+                // Calculate how many bytes to clear.
+                let len = copy_end - copy_start + 1;
+
+                buf.fill(buf_copy_start, len, 0)?;
+            }
+        }
+
+        Ok(len)
+    }
+
+    pub fn write(&mut self, offset: usize, buf: &dyn WriteBuf) -> Result<usize> {
+        let len = buf.buffer_len();
+        if len > 0 {
+            let start = offset;
+            let end = offset + len - 1;
+
+            let start_page = start / 0x1000;
+            let end_page = (end + 1).div_ceil(0x1000);
+
+            let mut cursor = self.pages.lower_bound_mut(Bound::Included(&start_page));
+            for i in start_page..end_page {
+                // If no page exists for the given index, create one.
+                if cursor.peek_next().is_none_or(|(idx, _)| *idx != i) {
+                    cursor.insert_after(i, KernelPage::zeroed()).unwrap();
+                }
+                // Get a reference to the page.
+                let (_, page) = cursor.next().unwrap();
+
+                // Calcuate the start and end indices of `page` in `self`.
+                let page_start = i * 0x1000;
+                let page_end = (i + 1) * 0x1000 - 1;
+
+                // Calculate the start and end indices in `self` for the copy
+                // operation.
+                let copy_start = cmp::max(page_start, start);
+                let copy_end = cmp::min(page_end, end);
+
+                // Calculate the start and end indices in `page` for the copy
+                // operation.
+                let page_copy_start = copy_start - page_start;
+                let page_copy_end = copy_end - page_start;
+                page.make_mut(true)?;
+                let dst = page.index(page_copy_start..=page_copy_end);
+
+                let buf_copy_start = copy_start - offset;
+                unsafe {
+                    buf.read_volatile(buf_copy_start, dst)?;
+                }
+            }
+        }
+
+        // Update the length.
+        self.len = cmp::max(self.len, offset + len);
+
+        Ok(len)
+    }
+
+    pub fn truncate(&mut self, len: usize) -> Result<()> {
+        let page_offset = len % 0x1000;
+        let page_index = len / 0x1000;
+        let mut cursor = self.pages.lower_bound_mut(Bound::Included(&page_index));
+
+        // If `len` isn't on a page boundary, clear the content towards the end.
+        if page_offset > 0 {
+            if let Some((_, page)) = cursor.peek_next().filter(|&(idx, _)| *idx == page_index) {
+                page.zero_range(page_offset.., true)?;
+                cursor.next();
+            }
+        }
+
+        // Remove all pages after `len`.
+        while cursor.remove_next().is_some() {}
+
+        self.len = len;
+
+        Ok(())
+    }
+
+    pub fn get_page(&mut self, page_idx: usize, shared: bool) -> Result<KernelPage> {
+        ensure!(page_idx * 0x1000 < self.len, Acces);
+
+        if shared {
+            let page = self
+                .pages
+                .entry(page_idx)
+                .or_insert_with(KernelPage::zeroed);
+
+            // Always make shared pages mutable immediately. We need to do this
+            // because we need to ensure that calling `make_mut(...)` on the
+            // returned pages doesn't allocate a new page every time.
+            page.make_mut(true)?;
+
+            page.clone()
+        } else if let Some(page) = self.pages.get_mut(&page_idx) {
+            page.clone()
+        } else {
+            Ok(KernelPage::zeroed())
+        }
+    }
+}


### PR DESCRIPTION
Some workloads use very large files with holes in them. In those cases, storing the pages in a vector isn't feasible. Instead, store them in a BTreeMap. This is slower, though, so we don't want to do that for all buffers, but just the ones that need to be sparse.