### PR TITLE
release lock in tgkill before queuing signal

### DIFF
--- a/tee/kernel/src/user/process/syscall.rs
+++ b/tee/kernel/src/user/process/syscall.rs
@@ -4206,6 +4206,7 @@ fn tgkill(thread: &Thread, tgid: u32, pid: u32, signal: Signal) -> SyscallResult
         .filter_map(Weak::upgrade)
         .find(|t| t.tid() == pid)
         .ok_or(err!(Srch))?;
+    drop(threads);
     thread.queue_signal(sig_info);
     Ok(0)
 }


### PR DESCRIPTION
This helps avoid deadlocks.