### PR TITLE
enable HLAT, PWA, and GPV when running on TDX

### DIFF
--- a/common/loader/src/elf.rs
+++ b/common/loader/src/elf.rs
@@ -45,7 +45,6 @@ pub fn load(
 
             let mut vmpl1_perms = VmplPermissions::empty();
             if execute {
-                vmpl1_perms |= VmplPermissions::EXECUTE_USER;
                 vmpl1_perms |= VmplPermissions::EXECUTE_SUPERVISOR;
             }
             if write {

--- a/common/loader/src/elf.rs
+++ b/common/loader/src/elf.rs
@@ -36,6 +36,7 @@ pub fn load(
             let execute = ph.p_flags.get_bit(0);
             let write = ph.p_flags.get_bit(1);
             let read = ph.p_flags.get_bit(2);
+            let paging_write_access = ph.p_flags.get_bit(26);
             let vmsa_page = ph.p_flags.get_bit(27);
             let cpuid_page = ph.p_flags.get_bit(28);
             let secrets_page = ph.p_flags.get_bit(29);
@@ -47,6 +48,11 @@ pub fn load(
                 vmpl1_perms |= VmplPermissions::EXECUTE_SUPERVISOR;
             }
             if write {
+                vmpl1_perms |= VmplPermissions::WRITE;
+            }
+            // AMD CPUs don't support PWA, so we also need to set the WRITE
+            // bit for these pages.
+            if paging_write_access {
                 vmpl1_perms |= VmplPermissions::WRITE;
             }
             if read {

--- a/common/loader/src/elf.rs
+++ b/common/loader/src/elf.rs
@@ -36,6 +36,7 @@ pub fn load(
             let execute = ph.p_flags.get_bit(0);
             let write = ph.p_flags.get_bit(1);
             let read = ph.p_flags.get_bit(2);
+            let _no_verify_guest_paging = ph.p_flags.get_bit(25);
             let paging_write_access = ph.p_flags.get_bit(26);
             let vmsa_page = ph.p_flags.get_bit(27);
             let cpuid_page = ph.p_flags.get_bit(28);

--- a/common/tdx-types/src/tdcall.rs
+++ b/common/tdx-types/src/tdcall.rs
@@ -43,6 +43,9 @@ impl MdFieldId {
     pub const VMX_GUEST_IA32_EFER: Self = Self::vmcs1(0x2806);
     pub const VMX_VM_ENTRY_CONTROL: Self = Self::vmcs1(0x4012);
     pub const VMX_VM_EXECUTION_CONTROL_SECONDARY_PROC_BASED: Self = Self::vmcs1(0x401E);
+    pub const VMX_VM_EXECUTION_CONTROL_TERTIARY_PROC_BASED: Self = Self::vmcs1(0x2034);
+    pub const VMX_HLATP: Self = Self::vmcs1(0x2040);
+    pub const VMX_HLAT_PREFIX_SIZE: Self = Self::vmcs1(0x0006);
     pub const VMX_GUEST_CS_ARBYTE: Self = Self::vmcs1(0x4816);
     pub const VMX_CR0_READ_SHADOW: Self = Self::vmcs1(0x6004);
     pub const VMX_CR4_READ_SHADOW: Self = Self::vmcs1(0x6006);

--- a/tee/kernel/linker.ld
+++ b/tee/kernel/linker.ld
@@ -3,7 +3,7 @@ ENTRY(reset_vector)
 PHDRS
 {
     headers             PT_LOAD FILEHDR PHDRS AT(0x08000000000) FLAGS(0);
-    pagetables          PT_LOAD AT(0x10000000000) FLAGS((1 << 1) | (1 << 2));
+    pagetables          PT_LOAD AT(0x10000000000) FLAGS((1 << 1) | (1 << 2) | (1 << 25));
     ropagetables        PT_LOAD AT(0x10000010000) FLAGS((1 << 2) | (1 << 26));
     reset_vector        PT_LOAD AT(0x10040000000);
     text                PT_LOAD AT(0x10040200000);

--- a/tee/kernel/linker.ld
+++ b/tee/kernel/linker.ld
@@ -3,7 +3,8 @@ ENTRY(reset_vector)
 PHDRS
 {
     headers             PT_LOAD FILEHDR PHDRS AT(0x08000000000) FLAGS(0);
-    pagetables          PT_LOAD AT(0x10000000000);
+    pagetables          PT_LOAD AT(0x10000000000) FLAGS((1 << 1) | (1 << 2));
+    ropagetables        PT_LOAD AT(0x10000010000) FLAGS((1 << 1) | (1 << 2));
     reset_vector        PT_LOAD AT(0x10040000000);
     text                PT_LOAD AT(0x10040200000);
     rodata              PT_LOAD AT(0x10080000000);
@@ -19,11 +20,19 @@ PHDRS
 SECTIONS {
     .pagetables (0x10000000000) : 
     {
+        . = 0x10000000000;
         KEEP(*(.pagetables.pml4 .pagetables.pml4.*))
         . = 0x10000001000;
         KEEP(*(.pagetables.tdx.pml4 .pagetables.tdx.pml4.*))
         KEEP(*(.pagetables .pagetables.*))
     } :pagetables
+
+    .ropagetables (0x10000010000) : 
+    {
+        . = 0x10000010000;
+        KEEP(*(.ropagetables.tdx.pml4 .ropagetables.tdx.pml4.*))
+        KEEP(*(.ropagetables .ropagetables.*))
+    } :ropagetables
 
     .reset_vector (0xffff800000000000) : 
     {

--- a/tee/kernel/linker.ld
+++ b/tee/kernel/linker.ld
@@ -4,7 +4,7 @@ PHDRS
 {
     headers             PT_LOAD FILEHDR PHDRS AT(0x08000000000) FLAGS(0);
     pagetables          PT_LOAD AT(0x10000000000) FLAGS((1 << 1) | (1 << 2));
-    ropagetables        PT_LOAD AT(0x10000010000) FLAGS((1 << 1) | (1 << 2));
+    ropagetables        PT_LOAD AT(0x10000010000) FLAGS((1 << 2) | (1 << 26));
     reset_vector        PT_LOAD AT(0x10040000000);
     text                PT_LOAD AT(0x10040200000);
     rodata              PT_LOAD AT(0x10080000000);

--- a/tee/kernel/src/memory/pagetable.rs
+++ b/tee/kernel/src/memory/pagetable.rs
@@ -57,7 +57,7 @@ static PML4: StaticPml4 = {
     page_table
 };
 
-#[unsafe(link_section = ".pagetables")]
+#[unsafe(link_section = ".ropagetables")]
 static PDP_256: StaticPdp = {
     let mut page_table = StaticPageTable::new();
     page_table.set_table(0, &PD_256_0, flags!(WRITE));
@@ -65,7 +65,7 @@ static PDP_256: StaticPdp = {
     page_table
 };
 
-#[unsafe(link_section = ".pagetables")]
+#[unsafe(link_section = ".ropagetables")]
 static PD_256_0: StaticPd = {
     let mut page_table = StaticPageTable::new();
     page_table.set_page(0, RESET_VECTOR, flags!(GLOBAL));
@@ -82,7 +82,7 @@ static PD_256_0: StaticPd = {
     page_table
 };
 
-#[unsafe(link_section = ".pagetables")]
+#[unsafe(link_section = ".ropagetables")]
 static PDP_352: StaticPdp = {
     let mut page_table = StaticPageTable::new();
     page_table.set_table(0, &PD_352_0, flags!(WRITE | EXECUTE_DISABLE));
@@ -91,7 +91,7 @@ static PDP_352: StaticPdp = {
     page_table
 };
 
-#[unsafe(link_section = ".pagetables")]
+#[unsafe(link_section = ".ropagetables")]
 static PD_352_0: StaticPd = {
     let mut page_table = StaticPageTable::new();
     page_table.set_page(0, TEXT_SHADOW, flags!(GLOBAL | EXECUTE_DISABLE));
@@ -102,21 +102,21 @@ static PD_352_0: StaticPd = {
     page_table
 };
 
-#[unsafe(link_section = ".pagetables")]
+#[unsafe(link_section = ".ropagetables")]
 static PD_352_72: StaticPd = {
     let mut page_table = StaticPageTable::new();
     page_table.set_page(0, INIT_FILE_SHADOW, flags!(GLOBAL | EXECUTE_DISABLE));
     page_table
 };
 
-#[unsafe(link_section = ".pagetables")]
+#[unsafe(link_section = ".ropagetables")]
 static PD_352_80: StaticPd = {
     let mut page_table = StaticPageTable::new();
     page_table.set_page(0, INPUT_FILE_SHADOW, flags!(GLOBAL | EXECUTE_DISABLE));
     page_table
 };
 
-#[unsafe(link_section = ".pagetables")]
+#[unsafe(link_section = ".ropagetables")]
 static PDP_257: StaticPdp = {
     let mut page_table = StaticPageTable::new();
     page_table.set_page_range(0, DYNAMIC, flags!(WRITE | GLOBAL | EXECUTE_DISABLE));
@@ -131,16 +131,26 @@ static PDP_257: StaticPdp = {
 #[used]
 #[unsafe(link_section = ".pagetables.tdx.pml4")]
 static TDX_PML4: StaticPml4 = {
-    let mut page_table = unsafe { PML4.clone() };
-    page_table.clear_entry(256);
-    page_table.set_table(256, &TDX_PDP_256, flags!(WRITE));
-    // Fix the recursive entry.
-    page_table.clear_entry(510);
+    // Most kernel mappings are set up through the HLAT PML4, so we can start
+    // with an empty PML4.
+    let mut page_table = StaticPageTable::new();
     page_table.set_recursive_table(510, &TDX_PML4, flags!(WRITE));
     page_table
 };
 
-#[unsafe(link_section = ".pagetables")]
+#[used]
+#[unsafe(link_section = ".ropagetables.tdx.pml4")]
+static TDX_HLAT_PML4: StaticPml4 = {
+    let mut page_table = unsafe { PML4.clone() };
+    page_table.clear_entry(256);
+    page_table.set_table(256, &TDX_PDP_256, flags!(WRITE));
+    // Clear the recursive entry. It should get translated through the regular page tables.
+    page_table.clear_entry(510);
+    page_table.fill_hlat_restart();
+    page_table
+};
+
+#[unsafe(link_section = ".ropagetables")]
 static TDX_PDP_256: StaticPdp = {
     let mut page_table = unsafe { PDP_256.clone() };
     page_table.clear_entry(0);
@@ -148,7 +158,7 @@ static TDX_PDP_256: StaticPdp = {
     page_table
 };
 
-#[unsafe(link_section = ".pagetables")]
+#[unsafe(link_section = ".ropagetables")]
 static TDX_PD_256_0: StaticPd = {
     let mut page_table = unsafe { PD_256_0.clone() };
     page_table.clear_entry(56);

--- a/tee/static-page-tables/src/lib.rs
+++ b/tee/static-page-tables/src/lib.rs
@@ -115,6 +115,22 @@ where
         }
     }
 
+    /// Configure all empty entries to restart HLAT translations using the
+    /// regular translations.
+    pub const fn fill_hlat_restart(&mut self) {
+        let flags = flags!(RESTART | PRESENT);
+        let restart_entry = null::<()>().wrapping_byte_add(flags.0);
+
+        let mut i = 0;
+        while i < 512 {
+            let entry = self.entries[i].get_mut();
+            if entry.is_null() {
+                *entry = restart_entry;
+            }
+            i += 1;
+        }
+    }
+
     /// Clear an entry.
     pub const fn clear_entry(&mut self, index: usize) {
         self.entries[index] = UnsafeCell::new(null_mut());
@@ -228,6 +244,7 @@ impl Flags {
     pub const DIRTY: Self = Self(1 << 6);
     pub const HUGE: Self = Self(1 << 7);
     pub const GLOBAL: Self = Self(1 << 8);
+    pub const RESTART: Self = Self(1 << 11);
     pub const C: Self = Self(1 << 51);
     pub const S: Self = Self(1 << 51);
     pub const EXECUTE_DISABLE: Self = Self(1 << 63);

--- a/tee/supervisor-tdx/src/input.rs
+++ b/tee/supervisor-tdx/src/input.rs
@@ -173,6 +173,7 @@ fn load_kernel() {
         attrs.set(GpaAttr::READ, ph.flags.get_bit(2));
         attrs.set(GpaAttr::WRITE, ph.flags.get_bit(1));
         attrs.set(GpaAttr::EXECUTE_SUPERVISOR, ph.flags.get_bit(0));
+        attrs.set(GpaAttr::VERIFY_GUEST_PAGING, !ph.flags.get_bit(25));
         attrs.set(GpaAttr::PAGE_WRITE_ACCESS, ph.flags.get_bit(26));
 
         let start = PhysAddr::new(ph.paddr);

--- a/tee/supervisor-tdx/src/input.rs
+++ b/tee/supervisor-tdx/src/input.rs
@@ -173,6 +173,7 @@ fn load_kernel() {
         attrs.set(GpaAttr::READ, ph.flags.get_bit(2));
         attrs.set(GpaAttr::WRITE, ph.flags.get_bit(1));
         attrs.set(GpaAttr::EXECUTE_SUPERVISOR, ph.flags.get_bit(0));
+        attrs.set(GpaAttr::PAGE_WRITE_ACCESS, ph.flags.get_bit(26));
 
         let start = PhysAddr::new(ph.paddr);
         let end = start + (ph.memsz - 1);

--- a/tee/supervisor-tdx/src/vcpu.rs
+++ b/tee/supervisor-tdx/src/vcpu.rs
@@ -92,12 +92,12 @@ pub fn init_vcpu() {
         );
     }
 
-    // Enable HLAT.
+    // Enable HLAT and EPT paging-write.
     unsafe {
         Tdcall::vp_wr(
             MdFieldId::VMX_VM_EXECUTION_CONTROL_TERTIARY_PROC_BASED,
-            1 << 1,
-            1 << 1,
+            (1 << 1) | (1 << 2),
+            (1 << 1) | (1 << 2),
         );
     }
 

--- a/tee/supervisor-tdx/src/vcpu.rs
+++ b/tee/supervisor-tdx/src/vcpu.rs
@@ -92,12 +92,12 @@ pub fn init_vcpu() {
         );
     }
 
-    // Enable HLAT and EPT paging-write.
+    // Enable HLAT, EPT paging-write, and guest-paging verification.
     unsafe {
         Tdcall::vp_wr(
             MdFieldId::VMX_VM_EXECUTION_CONTROL_TERTIARY_PROC_BASED,
-            (1 << 1) | (1 << 2),
-            (1 << 1) | (1 << 2),
+            (1 << 1) | (1 << 2) | (1 << 3),
+            (1 << 1) | (1 << 2) | (1 << 3),
         );
     }
 

--- a/tee/supervisor-tdx/src/vcpu.rs
+++ b/tee/supervisor-tdx/src/vcpu.rs
@@ -92,6 +92,21 @@ pub fn init_vcpu() {
         );
     }
 
+    // Enable HLAT.
+    unsafe {
+        Tdcall::vp_wr(
+            MdFieldId::VMX_VM_EXECUTION_CONTROL_TERTIARY_PROC_BASED,
+            1 << 1,
+            1 << 1,
+        );
+    }
+
+    // Configure HLAT.
+    unsafe {
+        Tdcall::vp_wr(MdFieldId::VMX_HLAT_PREFIX_SIZE, 1, u64::from(u16::MAX));
+        Tdcall::vp_wr(MdFieldId::VMX_HLATP, 0x100_0001_0000, !0);
+    }
+
     // Adjust CS segment.
     unsafe {
         Tdcall::vp_wr(MdFieldId::VMX_GUEST_CS_ARBYTE, 0xa09b, !0);


### PR DESCRIPTION
Intel CPUs have all these awesome security features, and enabling them is pretty easy, so let's use them.